### PR TITLE
Add RVM and chroma alpha hint generators for Apple Silicon / macOS

### DIFF
--- a/CorridorKeyModule/core/chroma_hint_generator.py
+++ b/CorridorKeyModule/core/chroma_hint_generator.py
@@ -1,0 +1,177 @@
+"""
+Adaptive chroma-key based alpha hint generator for CorridorKey.
+
+Generates soft foreground/background masks from green-screen footage using
+HSV color space analysis. Instead of hardcoding a generic "green" range,
+this samples the actual green screen color from the footage and builds a
+tight detection model around it.
+
+No AI model required. Works on any subject type (people, props, VFX elements).
+Instant — runs on any hardware.
+"""
+import os
+import cv2
+import numpy as np
+
+
+def sample_screen_color(frame_bgr):
+    """Detect the dominant green-screen color from a single frame.
+
+    Strategy: Two-pass approach.
+    1. Broad HSV pass finds anything vaguely green with decent saturation.
+    2. Compute median H/S/V of those pixels, then do a TIGHT second pass
+       around that median to isolate the core green-screen cluster.
+    3. Build the final detection range from the core cluster's distribution.
+
+    This adapts to the specific green screen — bright neon, dark fabric,
+    unevenly lit, etc. — while avoiding shadow/edge pixels that would
+    make the range too permissive.
+
+    Args:
+        frame_bgr: BGR uint8 numpy array [H, W, 3].
+
+    Returns:
+        Dict with HSV range, or None if no green screen detected.
+    """
+    hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV)
+
+    # Pass 1: Find anything greenish with reasonable saturation + brightness.
+    # Higher S/V floor than before — we want the well-lit green, not shadows.
+    broad_mask = cv2.inRange(hsv, (25, 50, 50), (95, 255, 255))
+
+    green_ratio = np.count_nonzero(broad_mask) / broad_mask.size
+    if green_ratio < 0.1:
+        return None
+
+    # Get median of the broad green pixels
+    green_pixels = hsv[broad_mask > 0]
+    h_med = np.median(green_pixels[:, 0])
+    s_med = np.median(green_pixels[:, 1])
+    v_med = np.median(green_pixels[:, 2])
+
+    # Pass 2: Tight window around the median to get the core cluster.
+    # This excludes shadow-green, spill-green, and edge pixels.
+    core_mask = cv2.inRange(hsv,
+                            (max(0, h_med - 15), max(0, s_med - 40), max(0, v_med - 50)),
+                            (min(180, h_med + 15), min(255, s_med + 40), min(255, v_med + 50)))
+    core_pixels = hsv[core_mask > 0]
+
+    if len(core_pixels) < 1000:
+        return None
+
+    h_vals = core_pixels[:, 0].astype(np.float32)
+    s_vals = core_pixels[:, 1].astype(np.float32)
+    v_vals = core_pixels[:, 2].astype(np.float32)
+
+    # Build detection range: adaptive hue, but keep S/V floors reasonable
+    # so we don't eat into dark clothing or desaturated areas.
+    h_pad = 10
+    s_pad = 15
+    v_pad = 20
+    color_profile = {
+        'h_low': max(0, np.percentile(h_vals, 5) - h_pad),
+        'h_high': min(180, np.percentile(h_vals, 95) + h_pad),
+        's_low': max(30, np.percentile(s_vals, 5) - s_pad),   # floor at 30
+        's_high': min(255, np.percentile(s_vals, 95) + s_pad),
+        'v_low': max(30, np.percentile(v_vals, 5) - v_pad),   # floor at 30
+        'v_high': min(255, np.percentile(v_vals, 95) + v_pad),
+        'h_median': float(np.median(h_vals)),
+        's_median': float(np.median(s_vals)),
+        'v_median': float(np.median(v_vals)),
+        'green_coverage': float(np.count_nonzero(core_mask) / core_mask.size),
+    }
+    return color_profile
+
+
+def generate_hint(frame_bgr, color_profile=None, blur_size=15):
+    """Generate an alpha hint mask for a single BGR frame.
+
+    Uses HSV color space to detect green-screen areas and marks everything
+    else as foreground. If a color_profile is provided (from sample_screen_color),
+    uses the tight adaptive range. Otherwise falls back to a broad default.
+
+    Args:
+        frame_bgr: BGR uint8 numpy array [H, W, 3].
+        color_profile: Optional dict from sample_screen_color().
+        blur_size: Gaussian blur kernel size for edge softening.
+
+    Returns:
+        numpy uint8 array [H, W] with values 0 (background/green) to
+        255 (foreground/subject).
+    """
+    hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV)
+
+    if color_profile:
+        lower = (int(color_profile['h_low']),
+                 int(color_profile['s_low']),
+                 int(color_profile['v_low']))
+        upper = (int(color_profile['h_high']),
+                 int(color_profile['s_high']),
+                 int(color_profile['v_high']))
+    else:
+        # Default broad green range
+        lower = (35, 40, 40)
+        upper = (85, 255, 255)
+
+    green_mask = cv2.inRange(hsv, lower, upper)
+
+    # Foreground = NOT green
+    mask = 255 - green_mask
+
+    # Soften edges for smooth gradient transitions
+    if blur_size > 0:
+        k = blur_size if blur_size % 2 == 1 else blur_size + 1
+        mask = cv2.GaussianBlur(mask, (k, k), 0)
+    return mask
+
+
+def generate_hints_for_video(video_path, output_dir, max_frames=None):
+    """Generate alpha hints for all frames in a video file.
+
+    Samples the green-screen color from the first frame, then uses that
+    tight color profile for all subsequent frames.
+
+    Args:
+        video_path: Path to input video.
+        output_dir: Directory to write hint PNGs.
+        max_frames: Optional limit on number of frames to process.
+
+    Returns:
+        Tuple of (frame_count, fps).
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    cap = cv2.VideoCapture(video_path)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    if max_frames:
+        total = min(total, max_frames)
+
+    color_profile = None
+    count = 0
+    while count < total:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        # Sample green-screen color from first frame
+        if count == 0:
+            color_profile = sample_screen_color(frame)
+            if color_profile:
+                print(f"  Screen color detected: H={color_profile['h_median']:.0f} "
+                      f"S={color_profile['s_median']:.0f} V={color_profile['v_median']:.0f} "
+                      f"(coverage: {color_profile['green_coverage']:.0%})")
+                print(f"  Adaptive range: H[{color_profile['h_low']:.0f}-{color_profile['h_high']:.0f}] "
+                      f"S[{color_profile['s_low']:.0f}-{color_profile['s_high']:.0f}] "
+                      f"V[{color_profile['v_low']:.0f}-{color_profile['v_high']:.0f}]")
+            else:
+                print("  No dominant green detected — using default broad range")
+
+        mask = generate_hint(frame, color_profile=color_profile)
+        cv2.imwrite(os.path.join(output_dir, f"{count:05d}.png"), mask)
+        count += 1
+        if (count % 100 == 0) or count == 1:
+            print(f"  Chroma hints: {count}/{total}")
+
+    cap.release()
+    return count, fps

--- a/CorridorKeyModule/core/prores_writer.py
+++ b/CorridorKeyModule/core/prores_writer.py
@@ -1,0 +1,38 @@
+import av
+import numpy as np
+from fractions import Fraction
+
+
+class ProResWriter:
+    """Writes RGBA frames to a ProRes 4444 .mov file with embedded alpha channel."""
+
+    def __init__(self, path, width, height, frame_rate=24):
+        self.container = av.open(path, mode='w')
+        rate = Fraction(frame_rate).limit_denominator(10000)
+        self.stream = self.container.add_stream('prores_ks', rate=rate)
+        self.stream.width = width
+        self.stream.height = height
+        self.stream.pix_fmt = 'yuva444p10le'
+        self.stream.options = {'profile': '4444'}  # ProRes 4444 profile
+
+    def write_frame(self, rgba_float):
+        """
+        Write a single RGBA frame.
+
+        Args:
+            rgba_float: numpy array [H, W, 4] float32, values in 0.0-1.0 range.
+                        RGB should be in display-referred (sRGB/Rec.709) space.
+                        Alpha should be linear.
+        """
+        # Convert float 0-1 to uint16 0-65535 for 16-bit interleaved RGBA
+        rgba_16 = (np.clip(rgba_float, 0.0, 1.0) * 65535).astype(np.uint16)
+        frame = av.VideoFrame.from_ndarray(rgba_16, format='rgba64le')
+        # Reformat to the stream's pixel format (yuva444p10le)
+        frame = frame.reformat(format=self.stream.pix_fmt)
+        for packet in self.stream.encode(frame):
+            self.container.mux(packet)
+
+    def close(self):
+        for packet in self.stream.encode():
+            self.container.mux(packet)
+        self.container.close()

--- a/CorridorKeyModule/core/rvm_hint_generator.py
+++ b/CorridorKeyModule/core/rvm_hint_generator.py
@@ -1,0 +1,112 @@
+"""
+Robust Video Matting (RVM) based alpha hint generator for CorridorKey.
+
+Uses PeterL1n's RVM (MobileNetV3 backbone) to generate foreground alpha mattes
+as hints. Fully automatic — no trimap, no interaction, no green-screen assumption.
+Understands "this is a person" semantically.
+
+Temporal consistency via recurrent ConvGRU states passed between frames.
+
+Model: rvm_mobilenetv3 (3.7M params, 14.5MB, ~30ms/frame on MPS)
+Default hint method on Apple Silicon.
+"""
+import os
+import cv2
+import numpy as np
+import torch
+from device_utils import resolve_device, clear_device_cache
+
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+
+class RVMHintGenerator:
+    def __init__(self, device=None, variant="mobilenetv3"):
+        self.device = torch.device(resolve_device(device))
+        self.model = torch.hub.load(
+            "PeterL1n/RobustVideoMatting", variant, trust_repo=True
+        )
+        self.model = self.model.eval().to(self.device)
+        self._rec = [None] * 4
+
+    def _pick_downsample_ratio(self, h, w):
+        """Choose downsample_ratio based on resolution.
+
+        The downsampled resolution should land between 256-512px for best
+        quality/speed tradeoff.
+        """
+        max_dim = max(h, w)
+        if max_dim > 2000:
+            return 0.125  # 4K
+        elif max_dim > 1200:
+            return 0.25   # FHD
+        else:
+            return 0.375  # HD or smaller
+
+    def reset(self):
+        """Reset recurrent states. Call between unrelated clips."""
+        self._rec = [None] * 4
+
+    def generate_hint(self, frame_bgr):
+        """Generate an alpha hint mask for a single BGR frame.
+
+        Maintains recurrent state between calls for temporal consistency.
+        Call reset() between unrelated clips.
+
+        Returns: numpy uint8 array [H, W] with values 0 (background) to 255 (foreground).
+        """
+        from torchvision.transforms.functional import to_tensor
+
+        h, w = frame_bgr.shape[:2]
+        ds_ratio = self._pick_downsample_ratio(h, w)
+
+        rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        src = to_tensor(rgb).unsqueeze(0).to(self.device)  # [1, 3, H, W]
+
+        with torch.no_grad():
+            fgr, pha, *self._rec = self.model(
+                src, *self._rec, downsample_ratio=ds_ratio
+            )
+
+        alpha = pha[0, 0].cpu().numpy()
+        mask = (np.clip(alpha, 0.0, 1.0) * 255).astype(np.uint8)
+        return mask
+
+    def generate_hints_for_video(self, video_path, output_dir, max_frames=None,
+                                 start_frame=0):
+        """Generate alpha hints for all frames in a video file.
+
+        Args:
+            video_path: Path to input video.
+            output_dir: Directory to write hint PNGs.
+            max_frames: Optional limit on number of frames to process.
+            start_frame: Frame index to start from (skip earlier frames).
+
+        Returns:
+            Tuple of (frame_count, fps).
+        """
+        os.makedirs(output_dir, exist_ok=True)
+        self.reset()
+
+        cap = cv2.VideoCapture(video_path)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        if start_frame > 0:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame)
+
+        if max_frames:
+            total = min(total - start_frame, max_frames)
+
+        count = 0
+        while count < total:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            mask = self.generate_hint(frame)
+            cv2.imwrite(os.path.join(output_dir, f"{count:05d}.png"), mask)
+            count += 1
+            if (count % 10 == 0) or count == 1:
+                print(f"  RVM hints: {count}/{total}")
+
+        cap.release()
+        return count, fps

--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -161,8 +161,11 @@ class CorridorKeyEngine:
 
             handle = self.model.refiner.register_forward_hook(scale_hook)
 
-        with torch.autocast(device_type=self.device.type, dtype=torch.float16):
+        if self.device.type == "cpu":
             out = self.model(inp_t)
+        else:
+            with torch.autocast(device_type=self.device.type, dtype=torch.float16):
+                out = self.model(inp_t)
 
         if handle:
             handle.remove()

--- a/CorridorKey_MACOS_Open_Me_In_Terminal.command
+++ b/CorridorKey_MACOS_Open_Me_In_Terminal.command
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Corridor Key Launcher - macOS / Linux
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+LOCAL_SCRIPT="$SCRIPT_DIR/corridorkey_cli.py"
+
+# Activate virtual environment
+if [ -f "$SCRIPT_DIR/venv/bin/activate" ]; then
+    source "$SCRIPT_DIR/venv/bin/activate"
+else
+    echo "[WARNING] No virtual environment found at $SCRIPT_DIR/venv"
+    echo "Run ./Install_CorridorKey_macOS.sh first."
+    read -p "Press enter to exit..."
+    exit 1
+fi
+
+# If no folder was provided as an argument, ask the user
+TARGET_PATH="$1"
+if [ -z "$TARGET_PATH" ]; then
+    echo "==================================================="
+    echo "    CorridorKey"
+    echo "==================================================="
+    echo ""
+    echo "Paste or type the path to your clips folder,"
+    echo "then press Enter:"
+    echo ""
+    read -r TARGET_PATH
+fi
+
+# Validate
+TARGET_PATH="${TARGET_PATH%/}"
+if [ -z "$TARGET_PATH" ]; then
+    echo "[ERROR] No path provided."
+    read -p "Press enter to exit..."
+    exit 1
+fi
+
+if [ ! -d "$TARGET_PATH" ]; then
+    echo "[ERROR] Not a valid folder: $TARGET_PATH"
+    read -p "Press enter to exit..."
+    exit 1
+fi
+
+echo ""
+echo "Starting Corridor Key..."
+echo "Target: $TARGET_PATH"
+echo ""
+
+python "$LOCAL_SCRIPT" --action wizard --win_path "$TARGET_PATH"
+
+read -p "Press enter to close..."

--- a/Install_CorridorKey_macOS.sh
+++ b/Install_CorridorKey_macOS.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Always run from the directory where this script lives
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+echo "==================================================="
+echo "    CorridorKey - macOS Auto-Installer"
+echo "==================================================="
+echo ""
+echo "Installing from: $SCRIPT_DIR"
+echo ""
+
+# 1. Find a suitable Python (3.10+)
+# Try common locations: python3 on PATH, then versioned Homebrew binaries
+PYTHON_CMD=""
+for candidate in python3 python3.13 python3.12 python3.11 python3.10 \
+                 /opt/homebrew/bin/python3.13 /opt/homebrew/bin/python3.12 \
+                 /opt/homebrew/bin/python3.11 /opt/homebrew/bin/python3.10; do
+    if command -v "$candidate" &> /dev/null; then
+        VERSION=$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        MAJOR=$(echo "$VERSION" | cut -d. -f1)
+        MINOR=$(echo "$VERSION" | cut -d. -f2)
+        if [ "$MAJOR" -ge 3 ] && [ "$MINOR" -ge 10 ]; then
+            PYTHON_CMD="$candidate"
+            echo "Found Python $VERSION ($candidate)"
+            break
+        fi
+    fi
+done
+
+if [ -z "$PYTHON_CMD" ]; then
+    echo "[ERROR] Python 3.10+ is required but not found!"
+    echo "Install it via: brew install python@3.12"
+    echo "Or download from https://www.python.org/downloads/"
+    exit 1
+fi
+
+# 2. Create Virtual Environment
+echo ""
+echo "[1/3] Setting up Python Virtual Environment..."
+if [ ! -d "venv" ]; then
+    "$PYTHON_CMD" -m venv venv
+else
+    # Check if existing venv meets the version requirement
+    VENV_VERSION=$(venv/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "0.0")
+    VENV_MAJOR=$(echo "$VENV_VERSION" | cut -d. -f1)
+    VENV_MINOR=$(echo "$VENV_VERSION" | cut -d. -f2)
+    if [ "$VENV_MAJOR" -lt 3 ] || ([ "$VENV_MAJOR" -eq 3 ] && [ "$VENV_MINOR" -lt 10 ]); then
+        echo "Existing venv uses Python $VENV_VERSION — recreating with $("$PYTHON_CMD" --version)..."
+        rm -rf venv
+        "$PYTHON_CMD" -m venv venv
+    else
+        echo "Virtual environment already exists (Python $VENV_VERSION)."
+    fi
+fi
+
+source venv/bin/activate
+
+# 3. Install Requirements
+echo ""
+echo "[2/3] Installing Dependencies (this might take a while)..."
+pip install --upgrade pip
+pip install .
+
+# On Apple Silicon, torch installs with MPS support automatically.
+# Verify MPS is available:
+python3 -c "
+import torch
+if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+    print('[OK] Apple Silicon MPS backend is available!')
+elif torch.cuda.is_available():
+    print('[OK] CUDA backend is available!')
+else:
+    print('[WARNING] No GPU acceleration detected. Inference will run on CPU (slow).')
+"
+
+# 4. Download Weights
+echo ""
+echo "[3/3] Downloading CorridorKey Model Weights..."
+mkdir -p CorridorKeyModule/checkpoints
+
+if [ ! -f "CorridorKeyModule/checkpoints/CorridorKey.pth" ]; then
+    echo "Downloading CorridorKey.pth..."
+    curl -L -o "CorridorKeyModule/checkpoints/CorridorKey.pth" \
+        "https://huggingface.co/nikopueringer/CorridorKey_v1.0/resolve/main/CorridorKey_v1.0.pth"
+else
+    echo "CorridorKey.pth already exists!"
+fi
+
+echo ""
+echo "==================================================="
+echo "  Setup Complete! You are ready to key!"
+echo "  Run: ./CorridorKey_DRAG_CLIPS_HERE_local.sh <clip_folder>"
+echo "==================================================="

--- a/clip_manager.py
+++ b/clip_manager.py
@@ -206,7 +206,13 @@ def get_corridor_key_engine(device: str = "cpu") -> CorridorKeyEngine:
         ckpt_path = ckpt_files[0]
         logger.info(f"Using checkpoint: {os.path.basename(ckpt_path)}")
 
-        return CorridorKeyEngine(checkpoint_path=ckpt_path, device=device, img_size=2048)
+        # MPS (Apple Silicon) produces noisy alpha at 2048 due to float16 precision.
+        # 1024 gives clean results and is well within MPS memory limits.
+        img_size = 1024 if device == "mps" else 2048
+        if img_size == 1024:
+            logger.info(f"Apple Silicon detected — using {img_size}x{img_size} inference (optimized for MPS)")
+
+        return CorridorKeyEngine(checkpoint_path=ckpt_path, device=device, img_size=img_size)
     except Exception as e:
         raise RuntimeError(f"Failed to initialize CorridorKey Engine: {e}") from e
 
@@ -284,6 +290,127 @@ def generate_alphas(clips: list[ClipEntry], device: str | None = None) -> None:
 
         except Exception as e:
             logger.error(f"Error generating alpha for {clip.name}: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+
+def generate_alphas_rvm(clips: list[ClipEntry], device: str | None = None) -> None:
+    """Generate alpha hints using RVM (Robust Video Matting).
+
+    Lightweight person-matting model (~14.5MB) that runs on MPS/CUDA/CPU.
+    Best for shots with people. Non-human subjects get near-zero detection.
+    """
+    clips_to_process = [c for c in clips if c.alpha_asset is None]
+
+    if not clips_to_process:
+        logger.info("All clips have valid Alpha assets. No generation needed.")
+        return
+
+    logger.info(f"Found {len(clips_to_process)} clips missing Alpha.")
+
+    if device is None:
+        device = resolve_device()
+
+    from CorridorKeyModule.core.rvm_hint_generator import RVMHintGenerator
+
+    rvm = RVMHintGenerator(device=device)
+
+    for clip in clips_to_process:
+        logger.info(f"Generating RVM Alpha for: {clip.name}")
+
+        alpha_output_dir = os.path.join(clip.root_path, "AlphaHint")
+        if os.path.exists(alpha_output_dir):
+            shutil.rmtree(alpha_output_dir)
+        os.makedirs(alpha_output_dir, exist_ok=True)
+
+        try:
+            rvm.reset()
+
+            if clip.input_asset.type == "video":
+                count, _fps = rvm.generate_hints_for_video(
+                    clip.input_asset.path, alpha_output_dir,
+                )
+                logger.info(f"RVM Complete: {count} frames -> {alpha_output_dir}")
+            else:
+                files = sorted([f for f in os.listdir(clip.input_asset.path) if is_image_file(f)])
+                for i, fname in enumerate(files):
+                    frame = cv2.imread(os.path.join(clip.input_asset.path, fname))
+                    if frame is None:
+                        continue
+                    mask = rvm.generate_hint(frame)
+                    cv2.imwrite(os.path.join(alpha_output_dir, f"{i:05d}.png"), mask)
+                    if (i + 1) % 10 == 0 or i == 0:
+                        print(f"  RVM hints: {i + 1}/{len(files)}")
+                logger.info(f"RVM Complete: {len(files)} frames -> {alpha_output_dir}")
+
+            clip.alpha_asset = ClipAsset(alpha_output_dir, "sequence")
+
+        except Exception as e:
+            logger.error(f"Error generating RVM alpha for {clip.name}: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+
+def generate_alphas_chroma(clips: list[ClipEntry]) -> None:
+    """Generate alpha hints using adaptive chroma keying.
+
+    HSV-based green screen detection — no model, no GPU needed.
+    Works on any subject type. Requires actual green screen coverage.
+    """
+    clips_to_process = [c for c in clips if c.alpha_asset is None]
+
+    if not clips_to_process:
+        logger.info("All clips have valid Alpha assets. No generation needed.")
+        return
+
+    logger.info(f"Found {len(clips_to_process)} clips missing Alpha.")
+
+    from CorridorKeyModule.core.chroma_hint_generator import (
+        generate_hints_for_video,
+        sample_screen_color,
+        generate_hint,
+    )
+
+    for clip in clips_to_process:
+        logger.info(f"Generating Chroma Alpha for: {clip.name}")
+
+        alpha_output_dir = os.path.join(clip.root_path, "AlphaHint")
+        if os.path.exists(alpha_output_dir):
+            shutil.rmtree(alpha_output_dir)
+        os.makedirs(alpha_output_dir, exist_ok=True)
+
+        try:
+            if clip.input_asset.type == "video":
+                count, _fps = generate_hints_for_video(
+                    clip.input_asset.path, alpha_output_dir,
+                )
+                logger.info(f"Chroma Complete: {count} frames -> {alpha_output_dir}")
+            else:
+                files = sorted([f for f in os.listdir(clip.input_asset.path) if is_image_file(f)])
+                color_profile = None
+                for i, fname in enumerate(files):
+                    frame = cv2.imread(os.path.join(clip.input_asset.path, fname))
+                    if frame is None:
+                        continue
+                    if i == 0:
+                        color_profile = sample_screen_color(frame)
+                        if color_profile:
+                            print(f"  Screen color: H={color_profile['h_median']:.0f} "
+                                  f"S={color_profile['s_median']:.0f} V={color_profile['v_median']:.0f}")
+                        else:
+                            print("  No green detected — using default broad range")
+                    mask = generate_hint(frame, color_profile=color_profile)
+                    cv2.imwrite(os.path.join(alpha_output_dir, f"{i:05d}.png"), mask)
+                    if (i + 1) % 100 == 0 or i == 0:
+                        print(f"  Chroma hints: {i + 1}/{len(files)}")
+                logger.info(f"Chroma Complete: {len(files)} frames -> {alpha_output_dir}")
+
+            clip.alpha_asset = ClipAsset(alpha_output_dir, "sequence")
+
+        except Exception as e:
+            logger.error(f"Error generating chroma alpha for {clip.name}: {e}")
             import traceback
 
             traceback.print_exc()
@@ -591,6 +718,19 @@ def run_inference(clips: list[ClipEntry], device: str | None = None) -> None:
             refiner_scale = 1.0
     logger.info(f"User selected: Refiner Strength {refiner_scale}")
 
+    # 5. ProRes 4444 Output Prompt
+    output_prores = False
+    prores_fps = 24.0
+    format_choice = input("Also output ProRes 4444 with alpha (.mov)? [y/N]: ").strip().lower()
+    if format_choice == "y":
+        output_prores = True
+        fps_val = input("Enter frame rate for ProRes output [default 24]: ").strip()
+        try:
+            prores_fps = float(fps_val) if fps_val else 24.0
+        except ValueError:
+            prores_fps = 24.0
+        logger.info(f"User selected: ProRes 4444 output at {prores_fps} fps")
+
     print("--------------------------\n")
 
     # Ensure Output Directory exists
@@ -615,6 +755,9 @@ def run_inference(clips: list[ClipEntry], device: str | None = None) -> None:
 
         for d in [fg_dir, matte_dir, comp_dir, proc_dir]:
             os.makedirs(d, exist_ok=True)
+
+        # ProRes writer (initialized lazily on first frame to get dimensions)
+        prores_writer = None
 
         num_frames = min(clip.input_asset.frame_count, clip.alpha_asset.frame_count)
         logger.info(
@@ -764,7 +907,26 @@ def run_inference(clips: list[ClipEntry], device: str | None = None) -> None:
                 proc_bgra = cv2.cvtColor(proc_rgba, cv2.COLOR_RGBA2BGRA)
                 cv2.imwrite(os.path.join(proc_dir, f"{input_stem}.exr"), proc_bgra, exr_flags)
 
+                # 7. Write ProRes 4444 frame (if enabled)
+                if output_prores:
+                    from CorridorKeyModule.core.color_utils import linear_to_srgb
+
+                    if prores_writer is None:
+                        from CorridorKeyModule.core.prores_writer import ProResWriter
+
+                        h_out, w_out = proc_rgba.shape[:2]
+                        prores_path = os.path.join(clip_out_root, f"{clip.name}_processed.mov")
+                        prores_writer = ProResWriter(prores_path, w_out, h_out, frame_rate=prores_fps)
+                        logger.info(f"Writing ProRes 4444: {prores_path}")
+                    # Convert linear premul RGB to sRGB for display-referred ProRes, keep alpha linear
+                    prores_rgba = proc_rgba.copy()
+                    prores_rgba[:, :, :3] = linear_to_srgb(prores_rgba[:, :, :3])
+                    prores_writer.write_frame(prores_rgba)
+
         print("")
+        if prores_writer:
+            prores_writer.close()
+            logger.info(f"ProRes 4444 output saved for {clip.name}.")
         if input_cap:
             input_cap.release()
         if alpha_cap:

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -25,6 +25,8 @@ from clip_manager import (
     LINUX_MOUNT_ROOT,
     ClipEntry,
     generate_alphas,
+    generate_alphas_chroma,
+    generate_alphas_rvm,
     is_video_file,
     map_path,
     organize_target,
@@ -222,8 +224,10 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
 
         print("\nACTIONS:")
         if missing_alpha:
-            print(f"  [v] Run VideoMaMa (Found {len(masked)} ready with masks)")
-            print(f"  [g] Run GVM (Auto-Matte on {len(raw)} clips without Mask Hint)")
+            print(f"  [m] Run RVM (person matting, {len(missing_alpha)} clips) [lightweight, Apple Silicon OK]")
+            print(f"  [c] Run Chroma Key (green screen, {len(missing_alpha)} clips) [no GPU needed]")
+            print(f"  [v] Run VideoMaMa (Found {len(masked)} ready with masks) [requires high VRAM]")
+            print(f"  [g] Run GVM (Auto-Matte on {len(raw)} clips without Mask Hint) [requires high VRAM]")
 
         if ready:
             print(f"  [i] Run Inference (on {len(ready)} ready clips)")
@@ -233,7 +237,25 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
 
         choice = input("\nSelect Action: ").strip().lower()
 
-        if choice == "v":
+        if choice == "m":
+            # RVM
+            print("\n--- RVM (Robust Video Matting) ---")
+            print("Best for: shots with people (semantic person detection)")
+            print("Limitation: non-human subjects get near-zero detection")
+            generate_alphas_rvm(missing_alpha, device=device)
+            input("RVM batch complete. Press Enter to Re-Scan...")
+            continue
+
+        elif choice == "c":
+            # Chroma
+            print("\n--- Adaptive Chroma Key ---")
+            print("Best for: green screen footage with any subject")
+            print("Limitation: requires actual green screen coverage")
+            generate_alphas_chroma(missing_alpha)
+            input("Chroma batch complete. Press Enter to Re-Scan...")
+            continue
+
+        elif choice == "v":
             # VideoMaMa
             print("\n--- VideoMaMa ---")
             print("Scanning for VideoMamaMaskHints...")


### PR DESCRIPTION
## Summary

- Two new lightweight alpha hint generators that run on Apple Silicon (MPS)
- macOS installer and launcher
- MPS inference fix (1024 resolution — 2048 produces noisy alpha due to float16 precision on MPS)
- CPU autocast safety guard in inference engine
- ProRes 4444 output option for final processed results

## What this enables

macOS users with Apple Silicon can now run the full CorridorKey pipeline:
**install → generate hints → run inference → get output**

Previously there was no working path — GVM and VideoMaMa require 80GB+ VRAM, and there were no lightweight alternatives.

## New hint generators

### RVM (Robust Video Matting) — wizard option `[m]`
- **56 ms/frame** on M4 Pro, 14.5MB model (MobileNetV3 backbone)
- Fully automatic — no trimap, no green screen needed
- Temporal consistency via recurrent ConvGRU states between frames
- Best for: shots with people
- Limitation: person-only (non-human subjects get near-zero detection)

### Adaptive Chroma — wizard option `[c]`
- **12 ms/frame** on M4 Pro, no model download needed
- Two-pass HSV sampling: detects the actual green screen color from frame 1, builds a tight detection range for all subsequent frames
- Best for: well-lit green screens with any subject type
- Limitation: requires actual green screen coverage (>10% of frame)

## MPS inference fix

CorridorKey inference at 2048 on Apple Silicon produces noisy, unusable alpha due to float16 precision limitations on MPS. At 1024, results are clean. `get_corridor_key_engine()` auto-detects MPS and sets 1024; CUDA stays at 2048.

Performance: ~1.65s/frame at 1024 on M4 Pro (24GB unified memory).

## ProRes 4444 output

Optional ProRes 4444 (.mov) output during inference. This writes the **final processed result** (despilled foreground + cleaned alpha, same data as the `Processed/*.exr` sequence) as a single video file into the clip's `Output/` folder. Useful for quick review or delivery without importing an EXR sequence. Prompted during inference settings — off by default.

## Integration with upstream

Rebased cleanly on top of current `main` (post-PR #33 merge). Changes build on upstream's architecture:

- Uses `device_utils.resolve_device()` from #33 for all device detection (no duplicate)
- Adds functions to `clip_manager.py` following upstream's patterns and type conventions
- Adds wizard menu options to `corridorkey_cli.py` (the extracted CLI from #8)
- CPU autocast guard in `inference_engine.py` (upstream uses `torch.autocast` unconditionally, which crashes on CPU)
- Does **not** modify `gvm_core/` or `VideoMaMaInferenceModule/`

## Files changed (8)

**New files:**
- `CorridorKeyModule/core/rvm_hint_generator.py` — RVM hint generator
- `CorridorKeyModule/core/chroma_hint_generator.py` — Adaptive chroma hint generator
- `CorridorKeyModule/core/prores_writer.py` — ProRes 4444 output writer
- `Install_CorridorKey_macOS.sh` — macOS installer (venv + pip)
- `CorridorKey_MACOS_Open_Me_In_Terminal.command` — macOS launcher (double-clickable)

**Modified files:**
- `clip_manager.py` — `generate_alphas_rvm()`, `generate_alphas_chroma()`, MPS img_size, ProRes output
- `corridorkey_cli.py` — `[m]` RVM and `[c]` chroma wizard menu options
- `CorridorKeyModule/inference_engine.py` — CPU autocast safety guard

## How to test

On Apple Silicon Mac:
```bash
# Install
chmod +x Install_CorridorKey_macOS.sh
./Install_CorridorKey_macOS.sh

# Run (or double-click CorridorKey_MACOS_Open_Me_In_Terminal.command)
python corridorkey_cli.py --action wizard --win_path /path/to/clips

# In wizard: select [m] for RVM hints or [c] for chroma hints
# Then [i] to run inference — should produce clean mattes at 1024
# Optional: say [y] to ProRes 4444 prompt for a .mov of the final processed output
```

## Benchmarks (M4 Pro, 24GB, 4K 145-frame clip)

| Stage | Total | Per-frame |
|-------|-------|-----------|
| RVM hints | 8.1s | 56 ms |
| Chroma hints | 1.8s | 12 ms |
| Inference (1024) | ~4 min | 1,653 ms |


🤖 Generated with [Claude Code](https://claude.com/claude-code)