### PR TITLE
Add backend service layer for GUI integration

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,71 @@
+"""Backend service layer for ez-CorridorKey."""
+
+from .clip_state import (
+    ClipAsset,
+    ClipEntry,
+    ClipState,
+    InOutRange,
+    scan_clips_dir,
+    scan_project_clips,
+)
+from .errors import CorridorKeyError
+from .job_queue import GPUJob, GPUJobQueue, JobStatus, JobType
+from .natural_sort import natsorted, natural_sort_key
+from .project import (
+    VIDEO_FILE_FILTER,
+    add_clips_to_project,
+    create_project,
+    get_clip_dirs,
+    get_display_name,
+    is_image_file,
+    is_v2_project,
+    is_video_file,
+    projects_root,
+    read_clip_json,
+    read_project_json,
+    sanitize_stem,
+    set_display_name,
+    write_clip_json,
+    write_project_json,
+)
+from .service import CorridorKeyService, InferenceParams, OutputConfig
+
+__all__ = [
+    # Service
+    "CorridorKeyService",
+    "InferenceParams",
+    "OutputConfig",
+    # Clip state
+    "ClipAsset",
+    "ClipEntry",
+    "ClipState",
+    "InOutRange",
+    "scan_clips_dir",
+    "scan_project_clips",
+    # Job queue
+    "GPUJob",
+    "GPUJobQueue",
+    "JobType",
+    "JobStatus",
+    # Errors
+    "CorridorKeyError",
+    # Project utilities
+    "projects_root",
+    "create_project",
+    "add_clips_to_project",
+    "sanitize_stem",
+    "get_clip_dirs",
+    "is_v2_project",
+    "write_project_json",
+    "read_project_json",
+    "write_clip_json",
+    "read_clip_json",
+    "get_display_name",
+    "set_display_name",
+    "is_video_file",
+    "is_image_file",
+    "VIDEO_FILE_FILTER",
+    # Natural sort
+    "natural_sort_key",
+    "natsorted",
+]

--- a/backend/clip_state.py
+++ b/backend/clip_state.py
@@ -1,0 +1,488 @@
+"""Clip entry data model and state machine.
+
+State Machine:
+    EXTRACTING — Video input being extracted to image sequence
+    RAW        — Input asset found, no alpha hint yet
+    MASKED     — User mask provided (for VideoMaMa workflow)
+    READY      — Alpha hint available (from GVM or VideoMaMa), ready for inference
+    COMPLETE   — Inference outputs written
+    ERROR      — Processing failed (can retry)
+
+Transitions:
+    EXTRACTING → RAW   (extraction completes)
+    EXTRACTING → ERROR (extraction fails)
+    RAW → MASKED       (user provides VideoMaMa mask)
+    RAW → READY        (GVM auto-generates alpha)
+    RAW → ERROR        (GVM/scan fails)
+    MASKED → READY     (VideoMaMa generates alpha from user mask)
+    MASKED → ERROR     (VideoMaMa fails)
+    READY → COMPLETE   (inference succeeds)
+    READY → ERROR      (inference fails)
+    ERROR → RAW        (retry from scratch)
+    ERROR → MASKED     (retry with mask)
+    ERROR → READY      (retry inference)
+    ERROR → EXTRACTING (retry extraction)
+    COMPLETE → READY   (reprocess with different params)
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from .errors import ClipScanError, InvalidStateTransitionError
+from .project import is_image_file as _is_image_file
+from .project import is_video_file as _is_video_file
+
+logger = logging.getLogger(__name__)
+
+
+class ClipState(Enum):
+    EXTRACTING = "EXTRACTING"
+    RAW = "RAW"
+    MASKED = "MASKED"
+    READY = "READY"
+    COMPLETE = "COMPLETE"
+    ERROR = "ERROR"
+
+
+# Valid transitions: from_state -> set of allowed to_states
+_TRANSITIONS: dict[ClipState, set[ClipState]] = {
+    ClipState.EXTRACTING: {ClipState.RAW, ClipState.ERROR},
+    ClipState.RAW: {ClipState.MASKED, ClipState.READY, ClipState.ERROR},
+    ClipState.MASKED: {ClipState.READY, ClipState.ERROR},
+    ClipState.READY: {ClipState.COMPLETE, ClipState.ERROR},
+    ClipState.COMPLETE: {ClipState.READY},  # reprocess with different params
+    ClipState.ERROR: {ClipState.RAW, ClipState.MASKED, ClipState.READY, ClipState.EXTRACTING},
+}
+
+
+@dataclass
+class ClipAsset:
+    """Represents an input source — either an image sequence directory or a video file."""
+
+    path: str
+    asset_type: str  # 'sequence' or 'video'
+    frame_count: int = 0
+
+    def __post_init__(self):
+        self._calculate_length()
+
+    def _calculate_length(self):
+        if self.asset_type == "sequence":
+            if os.path.isdir(self.path):
+                files = [f for f in os.listdir(self.path) if _is_image_file(f)]
+                self.frame_count = len(files)
+            else:
+                self.frame_count = 0
+        elif self.asset_type == "video":
+            try:
+                import cv2
+
+                cap = cv2.VideoCapture(self.path)
+                if cap.isOpened():
+                    self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                cap.release()
+            except Exception as e:
+                logger.debug(f"Video frame count detection failed for {self.path}: {e}")
+                self.frame_count = 0
+
+    def get_frame_files(self) -> list[str]:
+        """Return naturally sorted list of frame filenames for sequence assets.
+
+        Uses natural sort so frame_2 sorts before frame_10 (not lexicographic).
+        """
+        if self.asset_type != "sequence" or not os.path.isdir(self.path):
+            return []
+        from .natural_sort import natsorted
+
+        return natsorted([f for f in os.listdir(self.path) if _is_image_file(f)])
+
+
+@dataclass
+class InOutRange:
+    """In/out frame range for sub-clip processing. Both indices inclusive, 0-based."""
+
+    in_point: int
+    out_point: int
+
+    @property
+    def frame_count(self) -> int:
+        return self.out_point - self.in_point + 1
+
+    def contains(self, index: int) -> bool:
+        return self.in_point <= index <= self.out_point
+
+    def to_dict(self) -> dict:
+        return {"in_point": self.in_point, "out_point": self.out_point}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> InOutRange:
+        return cls(in_point=d["in_point"], out_point=d["out_point"])
+
+
+@dataclass
+class ClipEntry:
+    """A single shot/clip with its assets and processing state."""
+
+    name: str
+    root_path: str
+    state: ClipState = ClipState.RAW
+    input_asset: Optional[ClipAsset] = None
+    alpha_asset: Optional[ClipAsset] = None
+    mask_asset: Optional[ClipAsset] = None  # User-provided VideoMaMa mask
+    in_out_range: Optional[InOutRange] = None  # Per-clip in/out markers (None = full clip)
+    warnings: list[str] = field(default_factory=list)
+    error_message: Optional[str] = None
+    extraction_progress: float = 0.0  # 0.0 to 1.0 during EXTRACTING
+    extraction_total: int = 0  # total frames expected during extraction
+    _processing: bool = field(default=False, repr=False)  # lock: watcher must not reclassify
+
+    @property
+    def is_processing(self) -> bool:
+        """True while a GPU job is actively working on this clip."""
+        return self._processing
+
+    def set_processing(self, value: bool) -> None:
+        """Set processing lock. Watcher skips reclassification while True."""
+        self._processing = value
+
+    def transition_to(self, new_state: ClipState) -> None:
+        """Attempt a state transition. Raises InvalidStateTransitionError if not allowed."""
+        if new_state not in _TRANSITIONS.get(self.state, set()):
+            raise InvalidStateTransitionError(self.name, self.state.value, new_state.value)
+        old = self.state
+        self.state = new_state
+        if new_state != ClipState.ERROR:
+            self.error_message = None
+        logger.debug(f"Clip '{self.name}': {old.value} -> {new_state.value}")
+
+    def set_error(self, message: str) -> None:
+        """Transition to ERROR state with a message.
+
+        Works from any state that allows ERROR transition
+        (RAW, MASKED, READY — all can error now).
+        """
+        self.transition_to(ClipState.ERROR)
+        self.error_message = message
+
+    @property
+    def output_dir(self) -> str:
+        return os.path.join(self.root_path, "Output")
+
+    @property
+    def has_outputs(self) -> bool:
+        """Check if output directory exists with content."""
+        out = self.output_dir
+        if not os.path.isdir(out):
+            return False
+        for subdir in ("FG", "Matte", "Comp", "Processed"):
+            d = os.path.join(out, subdir)
+            if os.path.isdir(d) and os.listdir(d):
+                return True
+        return False
+
+    def completed_frame_count(self) -> int:
+        """Count existing output frames for resume support.
+
+        Manifest-aware: reads .corridorkey_manifest.json to determine which
+        outputs were enabled. Falls back to FG+Matte intersection if no manifest.
+        """
+        return len(self.completed_stems())
+
+    def completed_stems(self) -> set[str]:
+        """Return set of frame stems that have all enabled outputs complete.
+
+        Reads the run manifest to determine which outputs to check.
+        Falls back to FG+Matte intersection if no manifest exists.
+        """
+        manifest = self._read_manifest()
+        if manifest:
+            enabled = manifest.get("enabled_outputs", [])
+        else:
+            enabled = ["fg", "matte"]
+
+        dir_map = {
+            "fg": os.path.join(self.output_dir, "FG"),
+            "matte": os.path.join(self.output_dir, "Matte"),
+            "comp": os.path.join(self.output_dir, "Comp"),
+            "processed": os.path.join(self.output_dir, "Processed"),
+        }
+
+        stem_sets = []
+        for output_name in enabled:
+            d = dir_map.get(output_name)
+            if d and os.path.isdir(d):
+                stems = {os.path.splitext(f)[0] for f in os.listdir(d) if _is_image_file(f)}
+                stem_sets.append(stems)
+            else:
+                # Required dir missing → no complete frames
+                return set()
+
+        if not stem_sets:
+            return set()
+
+        # Intersection: frame complete only if ALL enabled outputs exist
+        result = stem_sets[0]
+        for s in stem_sets[1:]:
+            result &= s
+        return result
+
+    def _read_manifest(self) -> Optional[dict]:
+        """Read the run manifest if it exists."""
+        manifest_path = os.path.join(self.output_dir, ".corridorkey_manifest.json")
+        if not os.path.isfile(manifest_path):
+            return None
+        try:
+            import json
+
+            with open(manifest_path, "r") as f:
+                return json.load(f)
+        except Exception as e:
+            logger.debug(f"Failed to read manifest at {manifest_path}: {e}")
+            return None
+
+    def _resolve_original_path(self) -> Optional[str]:
+        """Resolve the original video path from clip.json or project.json."""
+        from .project import _read_clip_or_project_json
+
+        data = _read_clip_or_project_json(self.root_path)
+        if not data:
+            return None
+        source = data.get("source", {})
+        path = source.get("original_path")
+        if path and os.path.isfile(path):
+            return path
+        return None
+
+    def find_assets(self) -> None:
+        """Scan the clip directory for Input, AlphaHint, and mask assets.
+
+        Updates state accordingly. Supports both new format (Frames/, Source/)
+        and legacy format (Input/, Input.*) for backward compatibility.
+        """
+        # Input asset — check new names first, fall back to legacy
+        frames_dir = os.path.join(self.root_path, "Frames")
+        input_dir = os.path.join(self.root_path, "Input")
+        source_dir = os.path.join(self.root_path, "Source")
+
+        if os.path.isdir(frames_dir) and os.listdir(frames_dir):
+            self.input_asset = ClipAsset(frames_dir, "sequence")
+        elif os.path.isdir(input_dir) and os.listdir(input_dir):
+            self.input_asset = ClipAsset(input_dir, "sequence")
+        elif os.path.isdir(source_dir):
+            videos = [f for f in os.listdir(source_dir) if _is_video_file(f)]
+            if videos:
+                self.input_asset = ClipAsset(
+                    os.path.join(source_dir, videos[0]),
+                    "video",
+                )
+            else:
+                # Source/ exists but is empty — check project.json for external reference
+                original = self._resolve_original_path()
+                if original:
+                    self.input_asset = ClipAsset(original, "video")
+                else:
+                    raise ClipScanError(f"Clip '{self.name}': 'Source' dir has no video.")
+        else:
+            candidates = glob_module.glob(os.path.join(self.root_path, "[Ii]nput.*"))
+            candidates = [c for c in candidates if _is_video_file(c)]
+            if candidates:
+                self.input_asset = ClipAsset(candidates[0], "video")
+            elif os.path.isdir(input_dir):
+                raise ClipScanError(f"Clip '{self.name}': Input dir is empty — no image files.")
+            else:
+                raise ClipScanError(f"Clip '{self.name}': no Input found.")
+
+        # Load display name from project.json if available
+        from .project import get_display_name
+
+        display = get_display_name(self.root_path)
+        if display != os.path.basename(self.root_path):
+            self.name = display
+
+        # Alpha hint asset
+        alpha_dir = os.path.join(self.root_path, "AlphaHint")
+        if os.path.isdir(alpha_dir) and os.listdir(alpha_dir):
+            self.alpha_asset = ClipAsset(alpha_dir, "sequence")
+
+        # VideoMaMa mask hint — directory OR video file
+        mask_dir = os.path.join(self.root_path, "VideoMamaMaskHint")
+        if os.path.isdir(mask_dir) and os.listdir(mask_dir):
+            self.mask_asset = ClipAsset(mask_dir, "sequence")
+        else:
+            # Check for mask video file (VideoMamaMaskHint.mp4 etc.)
+            mask_candidates = glob_module.glob(os.path.join(self.root_path, "VideoMamaMaskHint.*"))
+            mask_candidates = [c for c in mask_candidates if _is_video_file(c)]
+            if mask_candidates:
+                self.mask_asset = ClipAsset(mask_candidates[0], "video")
+
+        # Load in/out range from project.json
+        from .project import load_in_out_range
+
+        self.in_out_range = load_in_out_range(self.root_path)
+
+        # Determine initial state
+        self._resolve_state()
+
+    def _resolve_state(self) -> None:
+        """Set state based on what assets are present on disk.
+
+        Recovers the furthest pipeline stage from disk contents so the
+        user never loses completed work after a restart or crash.
+
+        Priority (highest first):
+          COMPLETE  — all input frames have matching outputs (manifest-aware)
+          READY     — AlphaHint exists (inference-ready)
+          MASKED    — VideoMaMa mask hint exists
+          EXTRACTING — video source exists but no frame sequence yet
+          RAW       — frame sequence exists, no alpha/mask/output
+        """
+        # Check COMPLETE first: outputs exist and cover all input frames
+        if self.alpha_asset is not None and self.input_asset is not None:
+            completed = self.completed_stems()
+            if completed and len(completed) >= self.input_asset.frame_count:
+                self.state = ClipState.COMPLETE
+                return
+
+        # READY: AlphaHint must cover ALL input frames (not partial)
+        if self.alpha_asset is not None:
+            if self.input_asset is not None and self.alpha_asset.frame_count < self.input_asset.frame_count:
+                # Partial alpha — don't promote to READY, fall through
+                logger.info(
+                    f"Clip '{self.name}': partial alpha "
+                    f"({self.alpha_asset.frame_count}/{self.input_asset.frame_count}), "
+                    f"staying at lower state"
+                )
+            else:
+                self.state = ClipState.READY
+                return
+
+        if self.mask_asset is not None:
+            self.state = ClipState.MASKED
+        elif self.input_asset is not None and self.input_asset.asset_type == "video":
+            # Video input needs extraction to image sequence
+            self.state = ClipState.EXTRACTING
+        else:
+            self.state = ClipState.RAW
+
+
+def scan_project_clips(project_dir: str) -> list[ClipEntry]:
+    """Scan a single project directory for its clips.
+
+    v2 projects (with ``clips/`` subdir): each subdirectory inside clips/ is a clip.
+    v1 projects (no ``clips/`` subdir): the project dir itself is a single clip.
+
+    Args:
+        project_dir: Absolute path to a project folder.
+
+    Returns:
+        List of ClipEntry objects with root_path pointing to clip subdirectories.
+    """
+    from .project import is_v2_project
+
+    if is_v2_project(project_dir):
+        clips_dir = os.path.join(project_dir, "clips")
+        entries: list[ClipEntry] = []
+        for item in sorted(os.listdir(clips_dir)):
+            item_path = os.path.join(clips_dir, item)
+            if item.startswith(".") or item.startswith("_"):
+                continue
+            if not os.path.isdir(item_path):
+                continue
+            clip = ClipEntry(name=item, root_path=item_path)
+            try:
+                clip.find_assets()
+                entries.append(clip)
+            except ClipScanError as e:
+                logger.debug(str(e))
+        logger.info(f"Scanned v2 project {project_dir}: {len(entries)} clip(s)")
+        return entries
+
+    # v1 fallback: project_dir is itself a single clip
+    clip = ClipEntry(name=os.path.basename(project_dir), root_path=project_dir)
+    try:
+        clip.find_assets()
+        return [clip]
+    except ClipScanError as e:
+        logger.debug(str(e))
+        return []
+
+
+def scan_clips_dir(
+    clips_dir: str,
+    allow_standalone_videos: bool = True,
+) -> list[ClipEntry]:
+    """Scan a directory for clip folders and optionally standalone video files.
+
+    For the Projects root: iterates project subdirectories and delegates to
+    scan_project_clips() for each, flattening results.
+
+    For non-Projects directories: scans subdirectories directly as clips
+    (legacy behavior for drag-and-dropped folders).
+
+    Folders without valid input assets are skipped (not added as broken clips).
+
+    Args:
+        clips_dir: Path to scan.
+        allow_standalone_videos: If False, loose video files at top level are ignored.
+            Set False for the Projects root where videos live inside Source/ subdirs.
+    """
+    entries: list[ClipEntry] = []
+    if not os.path.isdir(clips_dir):
+        logger.warning(f"Clips directory not found: {clips_dir}")
+        return entries
+
+    # If the directory itself is a v2 project, scan its clips directly
+    from .project import is_v2_project
+
+    if is_v2_project(clips_dir):
+        return scan_project_clips(clips_dir)
+
+    seen_names: set[str] = set()
+
+    for item in sorted(os.listdir(clips_dir)):
+        item_path = os.path.join(clips_dir, item)
+
+        # Skip hidden and special items
+        if item.startswith(".") or item.startswith("_"):
+            continue
+
+        if os.path.isdir(item_path):
+            # Check if this is a v2 project container (has clips/ subdir)
+            from .project import is_v2_project
+
+            if is_v2_project(item_path):
+                # v2 project: scan its clips/ subdirectory
+                for clip in scan_project_clips(item_path):
+                    if clip.name not in seen_names:
+                        entries.append(clip)
+                        seen_names.add(clip.name)
+            else:
+                # Flat clip dir or v1 project
+                clip = ClipEntry(name=item, root_path=item_path)
+                try:
+                    clip.find_assets()
+                    entries.append(clip)
+                    seen_names.add(clip.name)
+                except ClipScanError as e:
+                    # Skip folders without valid input assets
+                    logger.debug(str(e))
+
+        elif allow_standalone_videos and os.path.isfile(item_path) and _is_video_file(item_path):
+            # Standalone video file → treat as a clip needing extraction
+            stem = os.path.splitext(item)[0]
+            if stem in seen_names:
+                continue  # folder clip already exists with this name
+            clip = ClipEntry(name=stem, root_path=clips_dir)
+            clip.input_asset = ClipAsset(item_path, "video")
+            clip.state = ClipState.EXTRACTING
+            entries.append(clip)
+            seen_names.add(stem)
+
+    logger.info(f"Scanned {clips_dir}: {len(entries)} clip(s) found")
+    return entries

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,0 +1,102 @@
+"""Typed exceptions for the CorridorKey backend."""
+
+
+class CorridorKeyError(Exception):
+    """Base exception for all CorridorKey backend errors."""
+
+    pass
+
+
+class ClipScanError(CorridorKeyError):
+    """Raised when a clip directory cannot be scanned or is malformed."""
+
+    pass
+
+
+class FrameMismatchError(CorridorKeyError):
+    """Raised when input and alpha frame counts don't match."""
+
+    def __init__(self, clip_name: str, input_count: int, alpha_count: int):
+        self.clip_name = clip_name
+        self.input_count = input_count
+        self.alpha_count = alpha_count
+        super().__init__(f"Clip '{clip_name}': frame count mismatch — input has {input_count}, alpha has {alpha_count}")
+
+
+class FrameReadError(CorridorKeyError):
+    """Raised when a frame file cannot be read."""
+
+    def __init__(self, clip_name: str, frame_index: int, path: str):
+        self.clip_name = clip_name
+        self.frame_index = frame_index
+        self.path = path
+        super().__init__(f"Clip '{clip_name}': failed to read frame {frame_index} ({path})")
+
+
+class WriteFailureError(CorridorKeyError):
+    """Raised when cv2.imwrite or similar write operation fails."""
+
+    def __init__(self, clip_name: str, frame_index: int, path: str):
+        self.clip_name = clip_name
+        self.frame_index = frame_index
+        self.path = path
+        super().__init__(f"Clip '{clip_name}': failed to write frame {frame_index} ({path})")
+
+
+class MaskChannelError(CorridorKeyError):
+    """Raised when a mask has unexpected channel count that can't be resolved."""
+
+    def __init__(self, clip_name: str, frame_index: int, channels: int):
+        self.clip_name = clip_name
+        self.frame_index = frame_index
+        self.channels = channels
+        super().__init__(f"Clip '{clip_name}': mask frame {frame_index} has {channels} channels, expected 1 or 3+")
+
+
+class VRAMInsufficientError(CorridorKeyError):
+    """Raised when there isn't enough GPU VRAM for the requested operation."""
+
+    def __init__(self, required_gb: float, available_gb: float):
+        self.required_gb = required_gb
+        self.available_gb = available_gb
+        super().__init__(f"Insufficient VRAM: {required_gb:.1f}GB required, {available_gb:.1f}GB available")
+
+
+class InvalidStateTransitionError(CorridorKeyError):
+    """Raised when a clip state transition is not allowed."""
+
+    def __init__(self, clip_name: str, current_state: str, target_state: str):
+        self.clip_name = clip_name
+        self.current_state = current_state
+        self.target_state = target_state
+        super().__init__(f"Clip '{clip_name}': invalid state transition {current_state} -> {target_state}")
+
+
+class JobCancelledError(CorridorKeyError):
+    """Raised when a GPU job is cancelled by the user."""
+
+    def __init__(self, clip_name: str, frame_index: int | None = None):
+        self.clip_name = clip_name
+        self.frame_index = frame_index
+        msg = f"Clip '{clip_name}': job cancelled"
+        if frame_index is not None:
+            msg += f" at frame {frame_index}"
+        super().__init__(msg)
+
+
+class FFmpegNotFoundError(CorridorKeyError):
+    """Raised when FFmpeg/FFprobe binaries cannot be located."""
+
+    def __init__(self):
+        super().__init__(
+            "FFmpeg not found. Install FFmpeg and ensure it is on PATH, or place it in C:\\Program Files\\ffmpeg\\bin\\"
+        )
+
+
+class ExtractionError(CorridorKeyError):
+    """Raised when video frame extraction fails."""
+
+    def __init__(self, clip_name: str, detail: str):
+        self.clip_name = clip_name
+        self.detail = detail
+        super().__init__(f"Clip '{clip_name}': extraction failed — {detail}")

--- a/backend/ffmpeg_tools.py
+++ b/backend/ffmpeg_tools.py
@@ -1,0 +1,405 @@
+"""FFmpeg subprocess wrapper for video extraction and stitching.
+
+Pure Python, no Qt deps. Provides:
+- find_ffmpeg() / find_ffprobe() — locate binaries
+- probe_video() — get fps, resolution, frame count, codec
+- extract_frames() — video -> image sequence (PNG)
+- stitch_video() — image sequence -> video (H.264)
+- write/read_video_metadata() — sidecar JSON for roundtrip fidelity
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_METADATA_FILENAME = ".video_metadata.json"
+
+# Common install locations on Windows
+_FFMPEG_SEARCH_PATHS = [
+    r"C:\Program Files\ffmpeg\bin",
+    r"C:\Program Files (x86)\ffmpeg\bin",
+    r"C:\ffmpeg\bin",
+]
+
+
+def find_ffmpeg() -> str | None:
+    """Locate ffmpeg binary. Checks PATH then common install dirs."""
+    found = shutil.which("ffmpeg")
+    if found:
+        return found
+    for d in _FFMPEG_SEARCH_PATHS:
+        candidate = os.path.join(d, "ffmpeg.exe")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def find_ffprobe() -> str | None:
+    """Locate ffprobe binary. Checks PATH then common install dirs."""
+    found = shutil.which("ffprobe")
+    if found:
+        return found
+    for d in _FFMPEG_SEARCH_PATHS:
+        candidate = os.path.join(d, "ffprobe.exe")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def probe_video(path: str) -> dict:
+    """Probe a video file for metadata.
+
+    Returns dict with keys: fps (float), width (int), height (int),
+    frame_count (int), codec (str), duration (float).
+    Raises RuntimeError if ffprobe fails.
+    """
+    ffprobe = find_ffprobe()
+    if not ffprobe:
+        raise RuntimeError("ffprobe not found")
+
+    cmd = [
+        ffprobe,
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_streams",
+        "-show_format",
+        path,
+    ]
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {result.stderr[:500]}")
+
+    data = json.loads(result.stdout)
+
+    # Find first video stream
+    video_stream = None
+    for stream in data.get("streams", []):
+        if stream.get("codec_type") == "video":
+            video_stream = stream
+            break
+
+    if not video_stream:
+        raise RuntimeError(f"No video stream found in {path}")
+
+    # Parse fps from r_frame_rate (e.g. "24000/1001")
+    fps_str = video_stream.get("r_frame_rate", "24/1")
+    if "/" in fps_str:
+        num, den = fps_str.split("/")
+        fps = float(num) / float(den) if float(den) != 0 else 24.0
+    else:
+        fps = float(fps_str)
+
+    # Frame count: prefer nb_frames, fall back to duration * fps
+    frame_count = 0
+    if "nb_frames" in video_stream:
+        try:
+            frame_count = int(video_stream["nb_frames"])
+        except (ValueError, TypeError):
+            pass
+
+    if frame_count <= 0:
+        duration = float(video_stream.get("duration", 0) or data.get("format", {}).get("duration", 0))
+        if duration > 0:
+            frame_count = int(duration * fps)
+
+    return {
+        "fps": round(fps, 4),
+        "width": int(video_stream.get("width", 0)),
+        "height": int(video_stream.get("height", 0)),
+        "frame_count": frame_count,
+        "codec": video_stream.get("codec_name", "unknown"),
+        "duration": float(video_stream.get("duration", 0) or data.get("format", {}).get("duration", 0)),
+    }
+
+
+def extract_frames(
+    video_path: str,
+    out_dir: str,
+    pattern: str = "frame_%06d.png",
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    cancel_event: Optional[threading.Event] = None,
+    total_frames: int = 0,
+) -> int:
+    """Extract video frames to PNG image sequence.
+
+    Args:
+        video_path: Path to input video file.
+        out_dir: Directory to write frames into (created if needed).
+        pattern: Frame filename pattern (FFmpeg style).
+        on_progress: Callback(current_frame, total_frames).
+        cancel_event: Set to cancel extraction.
+        total_frames: Expected total (for progress). Probed if 0.
+
+    Returns:
+        Number of frames extracted.
+
+    Raises:
+        RuntimeError if ffmpeg is not found or extraction fails.
+    """
+    ffmpeg = find_ffmpeg()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found")
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Probe for total if not provided
+    video_info = None
+    if total_frames <= 0:
+        try:
+            video_info = probe_video(video_path)
+            total_frames = video_info.get("frame_count", 0)
+        except Exception:
+            total_frames = 0
+
+    # Resume: detect existing frames and skip ahead with conservative rollback.
+    # Delete the last few frames (may be corrupt from mid-write or FFmpeg
+    # output buffering) and re-extract from that point.
+    _RESUME_ROLLBACK = 3  # frames to re-extract for safety
+    start_frame = 0
+    existing = sorted([f for f in os.listdir(out_dir) if f.lower().endswith(".png")])
+    if existing:
+        # Remove the last N frames — they may be corrupt or incomplete
+        remove_count = min(_RESUME_ROLLBACK, len(existing))
+        for fname in existing[-remove_count:]:
+            os.remove(os.path.join(out_dir, fname))
+        start_frame = max(0, len(existing) - remove_count)
+        if start_frame > 0:
+            logger.info(
+                f"Resuming extraction from frame {start_frame} ({len(existing)} existed, rolled back {remove_count})"
+            )
+
+    if start_frame > 0 and total_frames > 0:
+        # Seek to the resume point
+        if video_info is None:
+            video_info = probe_video(video_path)
+        fps = video_info.get("fps", 24.0)
+        seek_sec = start_frame / fps
+        cmd = [
+            ffmpeg,
+            "-ss",
+            f"{seek_sec:.4f}",
+            "-i",
+            video_path,
+            "-start_number",
+            str(start_frame),
+            "-vsync",
+            "passthrough",
+            out_dir + "/" + pattern,
+            "-y",
+        ]
+    else:
+        cmd = [
+            ffmpeg,
+            "-i",
+            video_path,
+            "-start_number",
+            "0",
+            "-vsync",
+            "passthrough",
+            out_dir + "/" + pattern,
+            "-y",
+        ]
+
+    logger.info(f"Extracting frames: {video_path} -> {out_dir} (start_frame={start_frame})")
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        text=True,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+
+    last_frame = start_frame
+    frame_re = re.compile(r"frame=\s*(\d+)")
+
+    # Read stderr in a background thread so cancel checks aren't blocked
+    import queue as _queue
+
+    line_q: _queue.Queue[str | None] = _queue.Queue()
+
+    def _reader():
+        for ln in proc.stderr:
+            line_q.put(ln)
+        line_q.put(None)  # sentinel
+
+    reader_thread = threading.Thread(target=_reader, daemon=True)
+    reader_thread.start()
+
+    try:
+        while True:
+            # Check cancellation every 0.2s even if no output
+            if cancel_event and cancel_event.is_set():
+                proc.kill()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+                logger.info("Extraction cancelled — FFmpeg killed")
+                return last_frame
+
+            try:
+                line = line_q.get(timeout=0.2)
+            except _queue.Empty:
+                # No output yet — check if process is still alive
+                if proc.poll() is not None:
+                    break
+                continue
+
+            if line is None:
+                break  # stderr closed — process ending
+
+            match = frame_re.search(line)
+            if match:
+                last_frame = start_frame + int(match.group(1))
+                if on_progress and total_frames > 0:
+                    on_progress(last_frame, total_frames)
+
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise RuntimeError("FFmpeg extraction timed out") from None
+
+    if proc.returncode != 0 and not (cancel_event and cancel_event.is_set()):
+        raise RuntimeError(f"FFmpeg extraction failed with code {proc.returncode}")
+
+    # Count actual extracted frames
+    extracted = len([f for f in os.listdir(out_dir) if f.lower().endswith(".png")])
+    logger.info(f"Extracted {extracted} frames to {out_dir}")
+    return extracted
+
+
+def stitch_video(
+    in_dir: str,
+    out_path: str,
+    fps: float = 24.0,
+    pattern: str = "frame_%06d.png",
+    codec: str = "libx264",
+    crf: int = 18,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    cancel_event: Optional[threading.Event] = None,
+) -> None:
+    """Stitch image sequence back into a video file.
+
+    Args:
+        in_dir: Directory containing frame images.
+        out_path: Output video file path.
+        fps: Frame rate.
+        pattern: Frame filename pattern.
+        codec: Video codec (libx264, libx265, etc.).
+        crf: Quality (0-51, lower = better).
+        on_progress: Callback(current_frame, total_frames).
+        cancel_event: Set to cancel stitching.
+
+    Raises:
+        RuntimeError if ffmpeg is not found or stitching fails.
+    """
+    ffmpeg = find_ffmpeg()
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found")
+
+    # Count total frames
+    total_frames = len([f for f in os.listdir(in_dir) if f.lower().endswith((".png", ".jpg", ".jpeg", ".exr"))])
+
+    cmd = [
+        ffmpeg,
+        "-framerate",
+        str(fps),
+        "-start_number",
+        "0",
+        "-i",
+        in_dir + "/" + pattern,
+        "-c:v",
+        codec,
+        "-crf",
+        str(crf),
+        "-pix_fmt",
+        "yuv420p",
+        out_path,
+        "-y",
+    ]
+
+    logger.info(f"Stitching video: {in_dir} -> {out_path}")
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        text=True,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+
+    frame_re = re.compile(r"frame=\s*(\d+)")
+
+    try:
+        for line in proc.stderr:
+            if cancel_event and cancel_event.is_set():
+                try:
+                    proc.stdin.write("q\n")
+                    proc.stdin.flush()
+                except Exception:
+                    pass
+                proc.wait(timeout=5)
+                logger.info("Stitching cancelled")
+                return
+
+            match = frame_re.search(line)
+            if match:
+                current = int(match.group(1))
+                if on_progress and total_frames > 0:
+                    on_progress(current, total_frames)
+
+        proc.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise RuntimeError("FFmpeg stitching timed out") from None
+
+    if proc.returncode != 0 and not (cancel_event and cancel_event.is_set()):
+        raise RuntimeError(f"FFmpeg stitching failed with code {proc.returncode}")
+
+    logger.info(f"Video stitched: {out_path}")
+
+
+def write_video_metadata(clip_root: str, metadata: dict) -> None:
+    """Write video metadata sidecar JSON to clip root.
+
+    Metadata typically includes: source_path, fps, width, height,
+    frame_count, codec, duration.
+    """
+    path = os.path.join(clip_root, _METADATA_FILENAME)
+    with open(path, "w") as f:
+        json.dump(metadata, f, indent=2)
+    logger.debug(f"Video metadata written: {path}")
+
+
+def read_video_metadata(clip_root: str) -> dict | None:
+    """Read video metadata sidecar from clip root. Returns None if not found."""
+    path = os.path.join(clip_root, _METADATA_FILENAME)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.debug(f"Failed to read video metadata: {e}")
+        return None

--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -1,0 +1,168 @@
+"""Unified frame I/O — read images and video frames as float32 RGB.
+
+All reading functions return float32 arrays in [0, 1] range with RGB channel
+order. EXR files are read as-is (linear float); standard formats (PNG, JPG,
+etc.) are normalized from uint8.
+
+This module consolidates frame-reading patterns that were previously duplicated
+across service.py methods (_read_input_frame, reprocess_single_frame,
+_load_frames_for_videomama, _load_mask_frames_for_videomama).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import cv2
+import numpy as np
+
+from .validators import normalize_mask_channels, normalize_mask_dtype
+
+# EXR write flags — PXR24 half-float (smallest working compression)
+EXR_WRITE_FLAGS = [
+    cv2.IMWRITE_EXR_TYPE,
+    cv2.IMWRITE_EXR_TYPE_HALF,
+    cv2.IMWRITE_EXR_COMPRESSION,
+    cv2.IMWRITE_EXR_COMPRESSION_PXR24,
+]
+
+
+def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np.ndarray]:
+    """Read an image file (EXR or standard) as float32 RGB [0, 1].
+
+    Args:
+        fpath: Absolute path to image file.
+        gamma_correct_exr: If True, apply gamma 1/2.2 to EXR data
+            (converts linear → approximate sRGB for models expecting sRGB).
+
+    Returns:
+        float32 array [H, W, 3] in RGB order, or None if read fails.
+    """
+    is_exr = fpath.lower().endswith(".exr")
+
+    if is_exr:
+        img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
+        if img is None:
+            return None
+        # Strip alpha channel from BGRA EXR
+        if img.ndim == 3 and img.shape[2] == 4:
+            img = img[:, :, :3]
+        img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        result = np.maximum(img_rgb, 0.0).astype(np.float32)
+        if gamma_correct_exr:
+            result = np.power(result, 1.0 / 2.2).astype(np.float32)
+        return result
+    else:
+        img = cv2.imread(fpath)
+        if img is None:
+            return None
+        img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        return img_rgb.astype(np.float32) / 255.0
+
+
+def read_video_frame_at(
+    video_path: str,
+    frame_index: int,
+) -> Optional[np.ndarray]:
+    """Read a single frame from a video by index, as float32 RGB [0, 1].
+
+    Args:
+        video_path: Path to video file.
+        frame_index: Zero-based frame index to seek to.
+
+    Returns:
+        float32 array [H, W, 3] in RGB order, or None if seek/read fails.
+    """
+    cap = cv2.VideoCapture(video_path)
+    try:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        ret, frame = cap.read()
+        if not ret:
+            return None
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    finally:
+        cap.release()
+
+
+def read_video_frames(
+    video_path: str,
+    processor: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+) -> list[np.ndarray]:
+    """Read all frames from a video, optionally applying a processor to each.
+
+    Without a processor, frames are returned as float32 RGB [0, 1].
+
+    Args:
+        video_path: Path to video file.
+        processor: Optional callable (BGR uint8 frame) → processed array.
+            If None, default conversion to float32 RGB [0, 1] is applied.
+
+    Returns:
+        List of processed frames.
+    """
+    frames: list[np.ndarray] = []
+    cap = cv2.VideoCapture(video_path)
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if processor is not None:
+                frames.append(processor(frame))
+            else:
+                img_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+                frames.append(img_rgb)
+    finally:
+        cap.release()
+    return frames
+
+
+def read_mask_frame(fpath: str, clip_name: str = "", frame_index: int = 0) -> Optional[np.ndarray]:
+    """Read a mask frame as float32 [H, W] in [0, 1].
+
+    Handles any channel count and dtype via normalize_mask_channels/dtype.
+
+    Args:
+        fpath: Path to mask image.
+        clip_name: For error context in normalization.
+        frame_index: For error context in normalization.
+
+    Returns:
+        float32 array [H, W] in [0, 1], or None if read fails.
+    """
+    mask_in = cv2.imread(fpath, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED)
+    if mask_in is None:
+        return None
+    # dtype normalization MUST happen before channel extraction, because
+    # normalize_mask_channels casts to float32 — which would make a uint8
+    # 255 into float32 255.0, skipping the /255 division in normalize_mask_dtype.
+    mask = normalize_mask_dtype(mask_in)
+    mask = normalize_mask_channels(mask, clip_name, frame_index)
+    return mask
+
+
+def read_video_mask_at(
+    video_path: str,
+    frame_index: int,
+) -> Optional[np.ndarray]:
+    """Read a single mask frame from a video by index, as float32 [H, W] [0, 1].
+
+    Extracts the blue channel (index 2) from BGR, matching the convention
+    used by alpha-channel video masks.
+
+    Args:
+        video_path: Path to video file.
+        frame_index: Zero-based frame index.
+
+    Returns:
+        float32 array [H, W] in [0, 1], or None if seek/read fails.
+    """
+    cap = cv2.VideoCapture(video_path)
+    try:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        ret, frame = cap.read()
+        if not ret:
+            return None
+        return frame[:, :, 2].astype(np.float32) / 255.0
+    finally:
+        cap.release()

--- a/backend/job_queue.py
+++ b/backend/job_queue.py
@@ -1,0 +1,324 @@
+"""GPU job queue with mutual exclusion.
+
+Ensures only ONE GPU job runs at a time across all job types
+(inference, GVM alpha gen, VideoMaMa alpha gen). This prevents VRAM
+contention — CorridorKey alone needs ~22.7GB of 24GB.
+
+Design:
+    - Thread-safe queue of GPUJob dataclasses
+    - Single consumer loop (designed to be driven by a QThread in the UI,
+      or called directly in CLI mode)
+    - Jobs carry a cancel flag checked between frames
+    - Callbacks for progress, warnings, completion, errors
+    - Jobs have stable IDs assigned at creation time
+    - Deduplication prevents double-submit of same clip+job_type
+    - Job history preserved for UI display (cancelled/completed/failed)
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Optional
+
+from .errors import JobCancelledError
+
+logger = logging.getLogger(__name__)
+
+
+class JobType(Enum):
+    INFERENCE = "inference"
+    GVM_ALPHA = "gvm_alpha"
+    VIDEOMAMA_ALPHA = "videomama_alpha"
+    PREVIEW_REPROCESS = "preview_reprocess"
+    VIDEO_EXTRACT = "video_extract"
+    VIDEO_STITCH = "video_stitch"
+
+
+class JobStatus(Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass
+class GPUJob:
+    """A single GPU job to be executed."""
+
+    job_type: JobType
+    clip_name: str
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:8])
+    params: dict[str, Any] = field(default_factory=dict)
+    status: JobStatus = JobStatus.QUEUED
+    _cancel_requested: bool = field(default=False, repr=False)
+    error_message: Optional[str] = None
+
+    # Progress tracking
+    current_frame: int = 0
+    total_frames: int = 0
+
+    def request_cancel(self) -> None:
+        """Signal that this job should stop at the next frame boundary."""
+        self._cancel_requested = True
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancel_requested
+
+    def check_cancelled(self) -> None:
+        """Raise JobCancelledError if cancel was requested. Call between frames."""
+        if self._cancel_requested:
+            raise JobCancelledError(self.clip_name, self.current_frame)
+
+
+# Callback type aliases
+ProgressCallback = Callable[[str, int, int], None]  # clip_name, current, total
+WarningCallback = Callable[[str], None]  # message
+CompletionCallback = Callable[[str], None]  # clip_name
+ErrorCallback = Callable[[str, str], None]  # clip_name, error_message
+
+
+class GPUJobQueue:
+    """Thread-safe GPU job queue with mutual exclusion.
+
+    Usage (CLI mode):
+        queue = GPUJobQueue()
+        queue.submit(GPUJob(JobType.INFERENCE, "shot1", params={...}))
+        queue.submit(GPUJob(JobType.GVM_ALPHA, "shot2", params={...}))
+
+        # Process all jobs sequentially
+        while queue.has_pending:
+            job = queue.next_job()
+            if job:
+                queue.start_job(job)
+                try:
+                    run_the_job(job)  # your processing function
+                    queue.complete_job(job)
+                except Exception as e:
+                    queue.fail_job(job, str(e))
+
+    Usage (GUI mode):
+        The GPU worker QThread calls next_job() / start_job() / complete_job()
+        in its run loop. The UI submits jobs from the main thread.
+    """
+
+    def __init__(self):
+        self._queue: deque[GPUJob] = deque()
+        self._lock = threading.Lock()
+        self._current_job: Optional[GPUJob] = None
+        self._history: list[GPUJob] = []  # completed/cancelled/failed jobs for UI display
+
+        # Callbacks (set by UI or CLI)
+        self.on_progress: Optional[ProgressCallback] = None
+        self.on_warning: Optional[WarningCallback] = None
+        self.on_completion: Optional[CompletionCallback] = None
+        self.on_error: Optional[ErrorCallback] = None
+
+    def submit(self, job: GPUJob) -> bool:
+        """Add a job to the queue. Returns False if duplicate detected.
+
+        PREVIEW_REPROCESS uses replacement semantics — any existing preview
+        reprocess in the queue is replaced by the new one (latest-only).
+        """
+        with self._lock:
+            # PREVIEW_REPROCESS: replace existing queued preview jobs (latest-only)
+            if job.job_type == JobType.PREVIEW_REPROCESS:
+                replaced = [j for j in self._queue if j.job_type == JobType.PREVIEW_REPROCESS]
+                for old in replaced:
+                    self._queue.remove(old)
+                    old.status = JobStatus.CANCELLED
+                    logger.debug(f"Preview reprocess [{old.id}] replaced by [{job.id}]")
+            else:
+                # Deduplication: reject if same clip+job_type already queued or running
+                for existing in self._queue:
+                    if existing.clip_name == job.clip_name and existing.job_type == job.job_type:
+                        logger.warning(
+                            f"Duplicate job rejected: {job.job_type.value} for '{job.clip_name}' "
+                            f"(already queued as {existing.id})"
+                        )
+                        return False
+                if (
+                    self._current_job
+                    and self._current_job.clip_name == job.clip_name
+                    and self._current_job.job_type == job.job_type
+                    and self._current_job.status == JobStatus.RUNNING
+                ):
+                    logger.warning(
+                        f"Duplicate job rejected: {job.job_type.value} for '{job.clip_name}' "
+                        f"(already running as {self._current_job.id})"
+                    )
+                    return False
+
+            job.status = JobStatus.QUEUED
+            self._queue.append(job)
+            logger.info(f"Job queued [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+            return True
+
+    def next_job(self) -> Optional[GPUJob]:
+        """Get the next pending job without starting it. Returns None if empty."""
+        with self._lock:
+            if self._queue:
+                return self._queue[0]
+            return None
+
+    def start_job(self, job: GPUJob) -> None:
+        """Mark a job as running. Must be called before processing."""
+        with self._lock:
+            if job in self._queue:
+                self._queue.remove(job)
+            job.status = JobStatus.RUNNING
+            self._current_job = job
+            logger.info(f"Job started [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+
+    def complete_job(self, job: GPUJob) -> None:
+        """Mark a job as successfully completed."""
+        with self._lock:
+            job.status = JobStatus.COMPLETED
+            if self._current_job is job:
+                self._current_job = None
+            self._history.append(job)
+            logger.info(f"Job completed [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+        # Emit AFTER lock release (Codex: no deadlock risk)
+        if self.on_completion:
+            self.on_completion(job.clip_name)
+
+    def fail_job(self, job: GPUJob, error: str) -> None:
+        """Mark a job as failed."""
+        with self._lock:
+            job.status = JobStatus.FAILED
+            job.error_message = error
+            if self._current_job is job:
+                self._current_job = None
+            self._history.append(job)
+            logger.error(f"Job failed [{job.id}]: {job.job_type.value} for '{job.clip_name}': {error}")
+        # Emit AFTER lock release
+        if self.on_error:
+            self.on_error(job.clip_name, error)
+
+    def mark_cancelled(self, job: GPUJob) -> None:
+        """Mark a running job as cancelled AND clear _current_job.
+
+        This is the cancel-safe path that was missing — calling
+        job.request_cancel() alone doesn't clear _current_job, which
+        poisons queue state for subsequent jobs.
+        """
+        with self._lock:
+            job.status = JobStatus.CANCELLED
+            if self._current_job is job:
+                self._current_job = None
+            self._history.append(job)
+            logger.info(f"Job cancelled [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+
+    def cancel_job(self, job: GPUJob) -> None:
+        """Request cancellation of a specific job."""
+        with self._lock:
+            if job.status == JobStatus.QUEUED:
+                if job in self._queue:
+                    self._queue.remove(job)
+                job.status = JobStatus.CANCELLED
+                self._history.append(job)
+                logger.info(f"Job removed from queue [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+            elif job.status == JobStatus.RUNNING:
+                # Signal cancel — worker calls mark_cancelled() after catching JobCancelledError
+                job.request_cancel()
+                logger.info(f"Job cancel requested [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+
+    def cancel_current(self) -> None:
+        """Cancel the currently running job, if any."""
+        with self._lock:
+            if self._current_job and self._current_job.status == JobStatus.RUNNING:
+                self._current_job.request_cancel()
+
+    def cancel_all(self) -> None:
+        """Cancel current job and clear the queue."""
+        with self._lock:
+            # Cancel current
+            if self._current_job and self._current_job.status == JobStatus.RUNNING:
+                self._current_job.request_cancel()
+            # Clear queue — preserve in history
+            for job in self._queue:
+                job.status = JobStatus.CANCELLED
+                self._history.append(job)
+            self._queue.clear()
+            logger.info("All jobs cancelled")
+
+    def report_progress(self, clip_name: str, current: int, total: int) -> None:
+        """Report progress for the current job. Called by processing code."""
+        if self._current_job:
+            self._current_job.current_frame = current
+            self._current_job.total_frames = total
+        if self.on_progress:
+            self.on_progress(clip_name, current, total)
+
+    def report_warning(self, message: str) -> None:
+        """Report a non-fatal warning. Called by processing code."""
+        logger.warning(message)
+        if self.on_warning:
+            self.on_warning(message)
+
+    def find_job_by_id(self, job_id: str) -> Optional[GPUJob]:
+        """Find a job by ID in queue, current, or history."""
+        with self._lock:
+            if self._current_job and self._current_job.id == job_id:
+                return self._current_job
+            for job in self._queue:
+                if job.id == job_id:
+                    return job
+            for job in self._history:
+                if job.id == job_id:
+                    return job
+        return None
+
+    def clear_history(self) -> None:
+        """Clear job history (for UI reset)."""
+        with self._lock:
+            self._history.clear()
+
+    def remove_job(self, job_id: str) -> None:
+        """Remove a single finished job from history."""
+        with self._lock:
+            self._history = [j for j in self._history if j.id != job_id]
+
+    @property
+    def has_pending(self) -> bool:
+        with self._lock:
+            return len(self._queue) > 0
+
+    @property
+    def current_job(self) -> Optional[GPUJob]:
+        with self._lock:
+            return self._current_job
+
+    @property
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._queue)
+
+    @property
+    def queue_snapshot(self) -> list[GPUJob]:
+        """Return a copy of the current queue for display purposes."""
+        with self._lock:
+            return list(self._queue)
+
+    @property
+    def history_snapshot(self) -> list[GPUJob]:
+        """Return a copy of job history for display purposes."""
+        with self._lock:
+            return list(self._history)
+
+    @property
+    def all_jobs_snapshot(self) -> list[GPUJob]:
+        """Return current + queued + history for full queue panel display."""
+        with self._lock:
+            result = []
+            if self._current_job:
+                result.append(self._current_job)
+            result.extend(self._queue)
+            result.extend(self._history)
+            return result

--- a/backend/natural_sort.py
+++ b/backend/natural_sort.py
@@ -1,0 +1,33 @@
+"""Natural sort key for frame filenames.
+
+Handles non-zero-padded frame numbers correctly:
+  frame_1, frame_2, frame_10  (not frame_1, frame_10, frame_2)
+
+No external dependency — pure Python implementation.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SPLIT_RE = re.compile(r"(\d+)")
+
+
+def natural_sort_key(text: str) -> list[str | int]:
+    """Return a sort key that orders numeric substrings numerically.
+
+    >>> sorted(['f_1', 'f_10', 'f_2'], key=natural_sort_key)
+    ['f_1', 'f_2', 'f_10']
+    """
+    parts: list[str | int] = []
+    for chunk in _SPLIT_RE.split(text):
+        if chunk.isdigit():
+            parts.append(int(chunk))
+        else:
+            parts.append(chunk.lower())
+    return parts
+
+
+def natsorted(items: list[str]) -> list[str]:
+    """Return a naturally sorted copy of a list of strings."""
+    return sorted(items, key=natural_sort_key)

--- a/backend/project.py
+++ b/backend/project.py
@@ -1,0 +1,385 @@
+"""Project folder management — creation, scanning, and metadata.
+
+A project is a timestamped container holding one or more clips:
+    Projects/
+        260301_093000_Woman_Jumps/
+            project.json                    (v2 — project-level metadata)
+            clips/
+                Woman_Jumps/                (ClipEntry.root_path → here)
+                    Source/
+                        Woman_Jumps_For_Joy.mp4
+                    Frames/
+                    AlphaHint/
+                    Output/FG/ Matte/ Comp/ Processed/
+                    clip.json               (per-clip metadata)
+                Man_Walks/
+                    Source/...
+
+Legacy v1 format (no clips/ dir) is still supported for backward compat.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".mkv", ".mxf", ".webm", ".m4v"})
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff", ".bmp", ".dpx"})
+VIDEO_FILE_FILTER = "Video Files (*.mp4 *.mov *.avi *.mkv *.mxf *.webm *.m4v);;All Files (*)"
+
+_app_dir: str | None = None
+
+
+def set_app_dir(path: str) -> None:
+    """Set the application directory. Called once at startup by main.py."""
+    global _app_dir
+    _app_dir = path
+
+
+def projects_root() -> str:
+    """Return the Projects root directory, creating it if needed.
+
+    In dev mode: {repo_root}/Projects/
+    In frozen mode: {exe_dir}/Projects/
+    """
+    if _app_dir:
+        root = os.path.join(_app_dir, "Projects")
+    elif getattr(sys, "frozen", False):
+        root = os.path.join(os.path.dirname(sys.executable), "Projects")
+    else:
+        # Fallback: two levels up from this file (backend/ -> repo root)
+        root = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "Projects")
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+def sanitize_stem(filename: str, max_len: int = 60) -> str:
+    """Clean a filename stem for use in folder names.
+
+    Strips extension, replaces non-alphanumeric chars with underscores,
+    collapses runs, and truncates.
+    """
+    stem = os.path.splitext(filename)[0]
+    stem = re.sub(r"[^\w\-]", "_", stem)
+    stem = re.sub(r"_+", "_", stem).strip("_")
+    return stem[:max_len]
+
+
+def create_project(
+    source_video_paths: str | list[str],
+    *,
+    copy_source: bool = True,
+    display_name: str | None = None,
+) -> str:
+    """Create a new project folder for one or more source videos.
+
+    Creates a v2 project with a ``clips/`` subdirectory.  Each video
+    gets its own clip subfolder inside ``clips/``.
+
+    When *copy_source* is True (default), video files are copied into
+    each clip's ``Source/`` directory.  When False, the clip stores a
+    reference to the original file path.
+
+    Creates: Projects/YYMMDD_HHMMSS_{stem}/clips/{clip_stem}/Source/...
+
+    Args:
+        source_video_paths: Single video path (str) or list of paths.
+        copy_source: Whether to copy video files into clip folders.
+        display_name: Optional project name. If provided, used for both
+            the folder name stem and display_name in project.json.
+            If None, derived from the first video filename.
+
+    Returns:
+        Absolute path to the new project folder.
+    """
+    # Accept single path for backward compat
+    if isinstance(source_video_paths, str):
+        source_video_paths = [source_video_paths]
+    if not source_video_paths:
+        raise ValueError("At least one source video path is required")
+
+    root = projects_root()
+
+    if display_name and display_name.strip():
+        clean = display_name.strip()
+        # Sanitize for folder name (no splitext — it's not a filename)
+        name_stem = re.sub(r"[^\w\-]", "_", clean)
+        name_stem = re.sub(r"_+", "_", name_stem).strip("_")[:60]
+        project_display_name = clean
+    else:
+        first_filename = os.path.basename(source_video_paths[0])
+        name_stem = sanitize_stem(first_filename)
+        project_display_name = name_stem.replace("_", " ")
+
+    timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+    folder_name = f"{timestamp}_{name_stem}"
+
+    # Deduplicate if folder already exists (e.g. rapid imports)
+    project_dir = os.path.join(root, folder_name)
+    if os.path.exists(project_dir):
+        for i in range(2, 100):
+            candidate = os.path.join(root, f"{folder_name}_{i}")
+            if not os.path.exists(candidate):
+                project_dir = candidate
+                break
+
+    clips_dir = os.path.join(project_dir, "clips")
+    os.makedirs(clips_dir, exist_ok=True)
+
+    clip_names: list[str] = []
+    for video_path in source_video_paths:
+        clip_name = _create_clip_folder(
+            clips_dir,
+            video_path,
+            copy_source=copy_source,
+        )
+        clip_names.append(clip_name)
+
+    # Write project.json (v2 — project-level metadata only)
+    write_project_json(
+        project_dir,
+        {
+            "version": 2,
+            "created": datetime.now().isoformat(),
+            "display_name": project_display_name,
+            "clips": clip_names,
+        },
+    )
+
+    return project_dir
+
+
+def add_clips_to_project(
+    project_dir: str,
+    source_video_paths: list[str],
+    *,
+    copy_source: bool = True,
+) -> list[str]:
+    """Add new clips to an existing project.
+
+    Args:
+        project_dir: Absolute path to the project folder.
+        source_video_paths: List of video file paths to add.
+        copy_source: Whether to copy videos into clip folders.
+
+    Returns:
+        List of new clip subfolder paths (absolute).
+    """
+    clips_dir = os.path.join(project_dir, "clips")
+    os.makedirs(clips_dir, exist_ok=True)
+
+    new_paths: list[str] = []
+    for video_path in source_video_paths:
+        clip_name = _create_clip_folder(
+            clips_dir,
+            video_path,
+            copy_source=copy_source,
+        )
+        new_paths.append(os.path.join(clips_dir, clip_name))
+
+    # Update project.json clips list
+    data = read_project_json(project_dir) or {}
+    existing = data.get("clips", [])
+    for p in new_paths:
+        existing.append(os.path.basename(p))
+    data["clips"] = existing
+    write_project_json(project_dir, data)
+
+    return new_paths
+
+
+def _create_clip_folder(
+    clips_dir: str,
+    video_path: str,
+    *,
+    copy_source: bool = True,
+) -> str:
+    """Create a single clip subfolder inside clips_dir.
+
+    Returns the clip folder name (not full path).
+    """
+    filename = os.path.basename(video_path)
+    clip_name = sanitize_stem(filename)
+
+    # Deduplicate clip folder names within same project
+    clip_dir = os.path.join(clips_dir, clip_name)
+    if os.path.exists(clip_dir):
+        for i in range(2, 100):
+            candidate = os.path.join(clips_dir, f"{clip_name}_{i}")
+            if not os.path.exists(candidate):
+                clip_dir = candidate
+                clip_name = f"{clip_name}_{i}"
+                break
+
+    source_dir = os.path.join(clip_dir, "Source")
+    os.makedirs(source_dir, exist_ok=True)
+
+    if copy_source:
+        target = os.path.join(source_dir, filename)
+        if not os.path.isfile(target):
+            shutil.copy2(video_path, target)
+            logger.info(f"Copied source video: {video_path} -> {target}")
+    else:
+        logger.info(f"Referencing source video in place: {video_path}")
+
+    # Write clip.json (per-clip metadata)
+    write_clip_json(
+        clip_dir,
+        {
+            "source": {
+                "original_path": os.path.abspath(video_path),
+                "filename": filename,
+                "copied": copy_source,
+            },
+        },
+    )
+
+    return clip_name
+
+
+def get_clip_dirs(project_dir: str) -> list[str]:
+    """Return absolute paths to all clip subdirectories in a project.
+
+    For v2 projects (with clips/ dir), scans clips/ subdirectories.
+    For v1 projects (no clips/ dir), returns [project_dir] as a single clip.
+    """
+    clips_dir = os.path.join(project_dir, "clips")
+    if os.path.isdir(clips_dir):
+        return sorted(
+            os.path.join(clips_dir, d)
+            for d in os.listdir(clips_dir)
+            if os.path.isdir(os.path.join(clips_dir, d)) and not d.startswith(".") and not d.startswith("_")
+        )
+    # v1 fallback: project dir itself is the clip
+    return [project_dir]
+
+
+def is_v2_project(project_dir: str) -> bool:
+    """Check if a project uses the v2 nested clips structure."""
+    return os.path.isdir(os.path.join(project_dir, "clips"))
+
+
+def write_project_json(project_root: str, data: dict) -> None:
+    """Atomic write of project.json."""
+    path = os.path.join(project_root, "project.json")
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp_path, path)
+
+
+def read_project_json(project_root: str) -> dict | None:
+    """Read project.json, returning None if missing or corrupt."""
+    path = os.path.join(project_root, "project.json")
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to read project.json at {path}: {e}")
+        return None
+
+
+def write_clip_json(clip_root: str, data: dict) -> None:
+    """Atomic write of clip.json (per-clip metadata)."""
+    path = os.path.join(clip_root, "clip.json")
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp_path, path)
+
+
+def read_clip_json(clip_root: str) -> dict | None:
+    """Read clip.json, returning None if missing or corrupt."""
+    path = os.path.join(clip_root, "clip.json")
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to read clip.json at {path}: {e}")
+        return None
+
+
+def _read_clip_or_project_json(root: str) -> dict | None:
+    """Read clip.json first, falling back to project.json for v1 compat."""
+    data = read_clip_json(root)
+    if data is not None:
+        return data
+    return read_project_json(root)
+
+
+def get_display_name(root: str) -> str:
+    """Get the user-visible name for a clip or project.
+
+    Checks clip.json first, then project.json, falling back to folder name.
+    """
+    data = _read_clip_or_project_json(root)
+    if data and data.get("display_name"):
+        return data["display_name"]
+    return os.path.basename(root)
+
+
+def set_display_name(root: str, name: str) -> None:
+    """Update display_name. Writes to clip.json if it exists, else project.json."""
+    if os.path.isfile(os.path.join(root, "clip.json")):
+        data = read_clip_json(root) or {}
+        data["display_name"] = name
+        write_clip_json(root, data)
+    else:
+        data = read_project_json(root) or {}
+        data["display_name"] = name
+        write_project_json(root, data)
+
+
+def save_in_out_range(clip_root: str, in_out) -> None:
+    """Persist in/out range to clip.json (v2) or project.json (v1).
+
+    Pass None to clear.
+    """
+    if os.path.isfile(os.path.join(clip_root, "clip.json")):
+        data = read_clip_json(clip_root) or {}
+        if in_out is not None:
+            data["in_out_range"] = in_out.to_dict()
+        else:
+            data.pop("in_out_range", None)
+        write_clip_json(clip_root, data)
+    else:
+        data = read_project_json(clip_root) or {}
+        if in_out is not None:
+            data["in_out_range"] = in_out.to_dict()
+        else:
+            data.pop("in_out_range", None)
+        write_project_json(clip_root, data)
+
+
+def load_in_out_range(clip_root: str):
+    """Load in/out range from clip.json or project.json, or None if not set."""
+    data = _read_clip_or_project_json(clip_root)
+    if data and "in_out_range" in data:
+        try:
+            from .clip_state import InOutRange
+
+            return InOutRange.from_dict(data["in_out_range"])
+        except (KeyError, TypeError):
+            return None
+    return None
+
+
+def is_video_file(filename: str) -> bool:
+    """Check if a filename has a video extension."""
+    return os.path.splitext(filename)[1].lower() in _VIDEO_EXTS
+
+
+def is_image_file(filename: str) -> bool:
+    """Check if a filename has an image extension."""
+    return os.path.splitext(filename)[1].lower() in _IMAGE_EXTS

--- a/backend/service.py
+++ b/backend/service.py
@@ -1,0 +1,1111 @@
+"""CorridorKeyService — clean backend API for the UI and CLI.
+
+This module wraps all processing logic from clip_manager.py into a
+service layer. The UI never calls inference engines directly — it
+calls methods here which handle validation, state transitions, and
+error reporting.
+
+Model Residency Policy:
+    Only ONE heavy model is loaded at a time. Before loading a new
+    model type, the previous is unloaded and VRAM freed via
+    device_utils.clear_device_cache(). This prevents OOM on 24GB cards.
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Callable, Optional
+
+import numpy as np
+
+# Enable OpenEXR support (must be before cv2 import)
+os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
+import cv2
+
+from .clip_state import (
+    ClipAsset,
+    ClipEntry,
+    ClipState,
+    scan_clips_dir,
+)
+from .errors import (
+    CorridorKeyError,
+    FrameReadError,
+    JobCancelledError,
+    WriteFailureError,
+)
+from .frame_io import (
+    EXR_WRITE_FLAGS,
+    read_image_frame,
+    read_mask_frame,
+    read_video_frame_at,
+    read_video_frames,
+    read_video_mask_at,
+)
+from .job_queue import GPUJob, GPUJobQueue
+from .validators import (
+    ensure_output_dirs,
+    validate_frame_counts,
+    validate_frame_read,
+    validate_write,
+)
+
+logger = logging.getLogger(__name__)
+
+# Project paths — frozen-build aware
+if getattr(sys, "frozen", False):
+    BASE_DIR = sys._MEIPASS
+else:
+    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class _ActiveModel(Enum):
+    """Tracks which heavy model is currently loaded in VRAM."""
+
+    NONE = "none"
+    INFERENCE = "inference"
+    GVM = "gvm"
+    VIDEOMAMA = "videomama"
+
+
+@dataclass
+class InferenceParams:
+    """Frozen parameters for a single inference job."""
+
+    input_is_linear: bool = False
+    despill_strength: float = 1.0  # 0.0 to 1.0
+    auto_despeckle: bool = True
+    despeckle_size: int = 400
+    despeckle_dilation: int = 25  # clean_matte dilation radius
+    despeckle_blur: int = 5  # clean_matte blur kernel half-size
+    refiner_scale: float = 1.0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "InferenceParams":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+@dataclass
+class OutputConfig:
+    """Which output types to produce and their format."""
+
+    fg_enabled: bool = True
+    fg_format: str = "exr"  # "exr" or "png"
+    matte_enabled: bool = True
+    matte_format: str = "exr"
+    comp_enabled: bool = True
+    comp_format: str = "png"
+    processed_enabled: bool = True
+    processed_format: str = "exr"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "OutputConfig":
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+    @property
+    def enabled_outputs(self) -> list[str]:
+        """Return list of enabled output names for manifest."""
+        out = []
+        if self.fg_enabled:
+            out.append("fg")
+        if self.matte_enabled:
+            out.append("matte")
+        if self.comp_enabled:
+            out.append("comp")
+        if self.processed_enabled:
+            out.append("processed")
+        return out
+
+
+@dataclass
+class FrameResult:
+    """Result summary for a single processed frame (no numpy in this struct)."""
+
+    frame_index: int
+    input_stem: str
+    success: bool
+    warning: Optional[str] = None
+
+
+class CorridorKeyService:
+    """Main backend service — scan, validate, process, write.
+
+    Usage:
+        service = CorridorKeyService()
+        clips = service.scan_clips("/path/to/ClipsForInference")
+        ready = service.get_clips_by_state(clips, ClipState.READY)
+
+        for clip in ready:
+            params = InferenceParams(despill_strength=0.8)
+            service.run_inference(clip, params, on_progress=my_callback)
+    """
+
+    def __init__(self):
+        self._engine = None
+        self._gvm_processor = None
+        self._videomama_pipeline = None
+        self._active_model = _ActiveModel.NONE
+        self._device: str = "cpu"
+        self._job_queue: Optional[GPUJobQueue] = None
+        # GPU mutex — serializes ALL model operations (Codex: thread safety)
+        self._gpu_lock = threading.Lock()
+
+    @property
+    def job_queue(self) -> GPUJobQueue:
+        """Lazy-init GPU job queue (only needed when UI is running)."""
+        if self._job_queue is None:
+            self._job_queue = GPUJobQueue()
+        return self._job_queue
+
+    # --- Device & Engine Management ---
+
+    def detect_device(self) -> str:
+        """Detect best available compute device using centralized device_utils."""
+        try:
+            from device_utils import resolve_device
+
+            self._device = resolve_device()
+        except ImportError:
+            self._device = "cpu"
+            logger.warning("device_utils not available — using CPU")
+        logger.info(f"Compute device: {self._device}")
+        return self._device
+
+    def get_vram_info(self) -> dict[str, float]:
+        """Get GPU VRAM info in GB. Returns empty dict if not CUDA."""
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                return {}
+            props = torch.cuda.get_device_properties(0)
+            total_bytes = props.total_mem
+            reserved = torch.cuda.memory_reserved(0)
+            return {
+                "total": total_bytes / (1024**3),
+                "reserved": reserved / (1024**3),
+                "allocated": torch.cuda.memory_allocated(0) / (1024**3),
+                "free": (total_bytes - reserved) / (1024**3),
+                "name": torch.cuda.get_device_name(0),
+            }
+        except Exception as e:
+            logger.debug(f"VRAM query failed: {e}")
+            return {}
+
+    @staticmethod
+    def _vram_allocated_mb() -> float:
+        """Return current VRAM allocated in MB, or 0 if unavailable."""
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                return torch.cuda.memory_allocated(0) / (1024**2)
+        except Exception:
+            pass
+        return 0.0
+
+    @staticmethod
+    def _safe_offload(obj: object) -> None:
+        """Move a model's GPU tensors to CPU before dropping the reference.
+
+        Handles diffusers pipelines (.to('cpu')), plain nn.Modules (.cpu()),
+        and objects with an explicit unload() method.
+        """
+        if obj is None:
+            return
+        logger.debug(f"Offloading model: {type(obj).__name__}")
+        try:
+            if hasattr(obj, "unload"):
+                obj.unload()
+            elif hasattr(obj, "to"):
+                obj.to("cpu")
+            elif hasattr(obj, "cpu"):
+                obj.cpu()
+        except Exception as e:
+            logger.debug(f"Model offload warning: {e}")
+
+    def _ensure_model(self, needed: _ActiveModel) -> None:
+        """Model residency manager — unload current model if switching types.
+
+        Only ONE heavy model stays in VRAM at a time. Before loading a
+        different model, the previous is moved to CPU and dereferenced.
+        """
+        if self._active_model == needed:
+            return
+
+        # Unload whatever is currently loaded
+        if self._active_model != _ActiveModel.NONE:
+            # Snapshot VRAM before unload for leak diagnosis
+            vram_before_mb = self._vram_allocated_mb()
+            logger.info(
+                f"Unloading {self._active_model.value} model for {needed.value} (VRAM before: {vram_before_mb:.0f}MB)"
+            )
+
+            if self._active_model == _ActiveModel.INFERENCE:
+                self._safe_offload(self._engine)
+                self._engine = None
+            elif self._active_model == _ActiveModel.GVM:
+                self._safe_offload(self._gvm_processor)
+                self._gvm_processor = None
+            elif self._active_model == _ActiveModel.VIDEOMAMA:
+                self._safe_offload(self._videomama_pipeline)
+                self._videomama_pipeline = None
+
+            import gc
+
+            gc.collect()
+
+            try:
+                from device_utils import clear_device_cache
+
+                clear_device_cache(self._device)
+            except ImportError:
+                logger.debug("device_utils not available for cache clear during model switch")
+
+            vram_after_mb = self._vram_allocated_mb()
+            freed = vram_before_mb - vram_after_mb
+            logger.info(f"VRAM after unload: {vram_after_mb:.0f}MB (freed {freed:.0f}MB)")
+
+        self._active_model = needed
+
+    def _get_engine(self):
+        """Lazy-load the CorridorKey inference engine."""
+        self._ensure_model(_ActiveModel.INFERENCE)
+
+        if self._engine is not None:
+            return self._engine
+
+        from CorridorKeyModule.inference_engine import CorridorKeyEngine
+
+        ckpt_dir = os.path.join(BASE_DIR, "CorridorKeyModule", "checkpoints")
+        ckpt_files = glob_module.glob(os.path.join(ckpt_dir, "*.pth"))
+
+        if len(ckpt_files) == 0:
+            raise FileNotFoundError(f"No .pth checkpoint found in {ckpt_dir}")
+        elif len(ckpt_files) > 1:
+            raise ValueError(
+                f"Multiple checkpoints found in {ckpt_dir}. "
+                f"Please ensure only one exists: {[os.path.basename(f) for f in ckpt_files]}"
+            )
+
+        ckpt_path = ckpt_files[0]
+        logger.info(f"Loading checkpoint: {os.path.basename(ckpt_path)}")
+        t0 = time.monotonic()
+        self._engine = CorridorKeyEngine(
+            checkpoint_path=ckpt_path,
+            device=self._device,
+            img_size=2048,
+        )
+        logger.info(f"Engine loaded in {time.monotonic() - t0:.1f}s")
+        return self._engine
+
+    def _get_gvm(self):
+        """Lazy-load the GVM processor."""
+        self._ensure_model(_ActiveModel.GVM)
+
+        if self._gvm_processor is not None:
+            return self._gvm_processor
+
+        from gvm_core import GVMProcessor
+
+        logger.info("Loading GVM processor...")
+        t0 = time.monotonic()
+        self._gvm_processor = GVMProcessor(device=self._device)
+        logger.info(f"GVM loaded in {time.monotonic() - t0:.1f}s")
+        return self._gvm_processor
+
+    def _get_videomama_pipeline(self):
+        """Lazy-load the VideoMaMa inference pipeline."""
+        self._ensure_model(_ActiveModel.VIDEOMAMA)
+
+        if self._videomama_pipeline is not None:
+            return self._videomama_pipeline
+
+        sys.path.insert(0, os.path.join(BASE_DIR, "VideoMaMaInferenceModule"))
+        from VideoMaMaInferenceModule.inference import load_videomama_model
+
+        logger.info("Loading VideoMaMa pipeline...")
+        t0 = time.monotonic()
+        self._videomama_pipeline = load_videomama_model(device=self._device)
+        logger.info(f"VideoMaMa loaded in {time.monotonic() - t0:.1f}s")
+        return self._videomama_pipeline
+
+    def unload_engines(self) -> None:
+        """Free GPU memory by unloading all engines."""
+        self._safe_offload(self._engine)
+        self._safe_offload(self._gvm_processor)
+        self._safe_offload(self._videomama_pipeline)
+        self._engine = None
+        self._gvm_processor = None
+        self._videomama_pipeline = None
+        self._active_model = _ActiveModel.NONE
+        try:
+            from device_utils import clear_device_cache
+
+            clear_device_cache(self._device)
+        except ImportError:
+            logger.debug("device_utils not available for cache clear during unload")
+        logger.info("All engines unloaded, VRAM freed")
+
+    # --- Clip Scanning ---
+
+    def scan_clips(
+        self,
+        clips_dir: str,
+        allow_standalone_videos: bool = True,
+    ) -> list[ClipEntry]:
+        """Scan a directory for clip folders."""
+        return scan_clips_dir(clips_dir, allow_standalone_videos=allow_standalone_videos)
+
+    def get_clips_by_state(
+        self,
+        clips: list[ClipEntry],
+        state: ClipState,
+    ) -> list[ClipEntry]:
+        """Filter clips by state."""
+        return [c for c in clips if c.state == state]
+
+    # --- Frame I/O Helpers ---
+
+    def _read_input_frame(
+        self,
+        clip: ClipEntry,
+        frame_index: int,
+        input_files: list[str],
+        input_cap: Optional[Any],
+        input_is_linear: bool,
+    ) -> tuple[Optional[np.ndarray], str, bool]:
+        """Read a single input frame.
+
+        Returns:
+            (image_float32, stem_name, is_linear_override)
+        """
+        logger.debug(f"Reading input frame {frame_index} for '{clip.name}'")
+        input_stem = f"{frame_index:05d}"
+
+        if input_cap:
+            ret, frame = input_cap.read()
+            if not ret:
+                return None, input_stem, False
+            img_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            return img_rgb.astype(np.float32) / 255.0, input_stem, input_is_linear
+        else:
+            fpath = os.path.join(clip.input_asset.path, input_files[frame_index])
+            input_stem = os.path.splitext(input_files[frame_index])[0]
+            img = read_image_frame(fpath)
+            validate_frame_read(img, clip.name, frame_index, fpath)
+            return img, input_stem, input_is_linear
+
+    def _read_alpha_frame(
+        self,
+        clip: ClipEntry,
+        frame_index: int,
+        alpha_files: list[str],
+        alpha_cap: Optional[Any],
+    ) -> Optional[np.ndarray]:
+        """Read a single alpha/mask frame and normalize to [H, W] float32."""
+        if alpha_cap:
+            ret, frame = alpha_cap.read()
+            if not ret:
+                return None
+            return frame[:, :, 2].astype(np.float32) / 255.0
+        else:
+            fpath = os.path.join(clip.alpha_asset.path, alpha_files[frame_index])
+            mask = read_mask_frame(fpath, clip.name, frame_index)
+            validate_frame_read(mask, clip.name, frame_index, fpath)
+            return mask
+
+    def _write_image(
+        self,
+        img: np.ndarray,
+        path: str,
+        fmt: str,
+        clip_name: str,
+        frame_index: int,
+    ) -> None:
+        """Write a single image in the requested format."""
+        if fmt == "exr":
+            # EXR requires float32 — convert if uint8 (e.g. pre-converted comp)
+            if img.dtype == np.uint8:
+                img = img.astype(np.float32) / 255.0
+            elif img.dtype != np.float32:
+                img = img.astype(np.float32)
+            validate_write(cv2.imwrite(path, img, EXR_WRITE_FLAGS), clip_name, frame_index, path)
+        else:
+            # PNG 8-bit
+            if img.dtype != np.uint8:
+                img = (np.clip(img, 0.0, 1.0) * 255.0).astype(np.uint8)
+            validate_write(cv2.imwrite(path, img), clip_name, frame_index, path)
+
+    def _write_manifest(
+        self,
+        output_root: str,
+        output_config: OutputConfig,
+        params: InferenceParams,
+    ) -> None:
+        """Write run manifest recording expected outputs/extensions per run.
+
+        Codex: base resume on manifest, not hardcoded FG/Matte intersection.
+        Uses atomic write (tmp + rename) to prevent corruption.
+        """
+        manifest = {
+            "version": 1,
+            "enabled_outputs": output_config.enabled_outputs,
+            "formats": {
+                "fg": output_config.fg_format,
+                "matte": output_config.matte_format,
+                "comp": output_config.comp_format,
+                "processed": output_config.processed_format,
+            },
+            "params": params.to_dict(),
+        }
+        manifest_path = os.path.join(output_root, ".corridorkey_manifest.json")
+        tmp_path = manifest_path + ".tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(manifest, f, indent=2)
+            # Atomic replace (os.replace is atomic on both POSIX and Windows)
+            os.replace(tmp_path, manifest_path)
+        except Exception as e:
+            logger.warning(f"Failed to write manifest: {e}")
+
+    def _write_outputs(
+        self,
+        res: dict,
+        dirs: dict[str, str],
+        input_stem: str,
+        clip_name: str,
+        frame_index: int,
+        output_config: OutputConfig | None = None,
+    ) -> None:
+        """Write output types for a single frame respecting OutputConfig."""
+        cfg = output_config or OutputConfig()
+        logger.debug(f"Writing outputs for '{clip_name}' frame {frame_index} stem='{input_stem}'")
+
+        pred_fg = res["fg"]
+        pred_alpha = res["alpha"]
+
+        # FG
+        if cfg.fg_enabled:
+            fg_bgr = cv2.cvtColor(pred_fg, cv2.COLOR_RGB2BGR)
+            fg_path = os.path.join(dirs["fg"], f"{input_stem}.{cfg.fg_format}")
+            self._write_image(fg_bgr, fg_path, cfg.fg_format, clip_name, frame_index)
+
+        # Matte
+        if cfg.matte_enabled:
+            alpha = pred_alpha
+            if alpha.ndim == 3:
+                alpha = alpha[:, :, 0]
+            matte_path = os.path.join(dirs["matte"], f"{input_stem}.{cfg.matte_format}")
+            self._write_image(alpha, matte_path, cfg.matte_format, clip_name, frame_index)
+
+        # Comp
+        if cfg.comp_enabled:
+            comp_srgb = res["comp"]
+            comp_bgr = cv2.cvtColor(
+                (np.clip(comp_srgb, 0.0, 1.0) * 255.0).astype(np.uint8),
+                cv2.COLOR_RGB2BGR,
+            )
+            comp_path = os.path.join(dirs["comp"], f"{input_stem}.{cfg.comp_format}")
+            self._write_image(comp_bgr, comp_path, cfg.comp_format, clip_name, frame_index)
+
+        # Processed (RGBA premultiplied)
+        if cfg.processed_enabled and "processed" in res:
+            proc_rgba = res["processed"]
+            proc_bgra = cv2.cvtColor(proc_rgba, cv2.COLOR_RGBA2BGRA)
+            proc_path = os.path.join(dirs["processed"], f"{input_stem}.{cfg.processed_format}")
+            self._write_image(proc_bgra, proc_path, cfg.processed_format, clip_name, frame_index)
+
+    # --- Processing ---
+
+    def run_inference(
+        self,
+        clip: ClipEntry,
+        params: InferenceParams,
+        job: Optional[GPUJob] = None,
+        on_progress: Optional[Callable[[str, int, int], None]] = None,
+        on_warning: Optional[Callable[[str], None]] = None,
+        skip_stems: Optional[set[str]] = None,
+        output_config: Optional[OutputConfig] = None,
+        frame_range: Optional[tuple[int, int]] = None,
+    ) -> list[FrameResult]:
+        """Run CorridorKey inference on a single clip.
+
+        Args:
+            clip: Must be in READY or COMPLETE state with both input_asset and alpha_asset.
+            params: Frozen inference parameters.
+            job: Optional GPUJob for cancel checking.
+            on_progress: Called with (clip_name, current_frame, total_frames).
+            on_warning: Called with warning messages for non-fatal issues.
+            skip_stems: Set of frame stems to skip (for resume support).
+            output_config: Which outputs to write and their formats.
+
+        Returns:
+            List of FrameResult for each frame.
+
+        Raises:
+            JobCancelledError: If job.is_cancelled becomes True.
+            Various CorridorKeyError subclasses for fatal issues.
+        """
+        if clip.input_asset is None or clip.alpha_asset is None:
+            raise CorridorKeyError(f"Clip '{clip.name}' missing input or alpha asset")
+
+        t_start = time.monotonic()
+
+        with self._gpu_lock:
+            engine = self._get_engine()
+        dirs = ensure_output_dirs(clip.root_path)
+        cfg = output_config or OutputConfig()
+
+        # Write run manifest (Codex: resume must know which outputs were enabled)
+        self._write_manifest(dirs["root"], cfg, params)
+
+        num_frames = validate_frame_counts(
+            clip.name,
+            clip.input_asset.frame_count,
+            clip.alpha_asset.frame_count,
+        )
+
+        # Open video captures or get file lists
+        input_cap = None
+        alpha_cap = None
+        input_files: list[str] = []
+        alpha_files: list[str] = []
+
+        if clip.input_asset.asset_type == "video":
+            input_cap = cv2.VideoCapture(clip.input_asset.path)
+        else:
+            input_files = clip.input_asset.get_frame_files()
+
+        if clip.alpha_asset.asset_type == "video":
+            alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
+        else:
+            alpha_files = clip.alpha_asset.get_frame_files()
+
+        results: list[FrameResult] = []
+        skipped: list[int] = []
+        skip_stems = skip_stems or set()
+
+        # Determine frame range (in/out markers or full clip)
+        if frame_range is not None:
+            range_start = max(0, frame_range[0])
+            range_end = min(num_frames - 1, frame_range[1])
+            frame_indices = range(range_start, range_end + 1)
+            range_count = range_end - range_start + 1
+        else:
+            frame_indices = range(num_frames)
+            range_count = num_frames
+
+        try:
+            for progress_i, i in enumerate(frame_indices):
+                # Check cancellation between frames
+                if job and job.is_cancelled:
+                    raise JobCancelledError(clip.name, i)
+
+                # Report progress every frame (enables responsive cancel + timer)
+                if on_progress:
+                    on_progress(clip.name, progress_i, range_count)
+
+                try:
+                    # Read input
+                    img, input_stem, is_linear = self._read_input_frame(
+                        clip,
+                        i,
+                        input_files,
+                        input_cap,
+                        params.input_is_linear,
+                    )
+                    if img is None:
+                        skipped.append(i)
+                        results.append(FrameResult(i, f"{i:05d}", False, "video read failed"))
+                        continue
+
+                    # Resume: skip frames that already have outputs
+                    if input_stem in skip_stems:
+                        results.append(FrameResult(i, input_stem, True, "resumed (skipped)"))
+                        continue
+
+                    # Read alpha
+                    mask = self._read_alpha_frame(clip, i, alpha_files, alpha_cap)
+                    if mask is None:
+                        skipped.append(i)
+                        results.append(FrameResult(i, input_stem, False, "alpha read failed"))
+                        continue
+
+                    # Resize mask if dimensions don't match input
+                    if mask.shape[:2] != img.shape[:2]:
+                        mask = cv2.resize(mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR)
+
+                    # Process (GPU-locked — process_frame mutates model hooks)
+                    t_frame = time.monotonic()
+                    with self._gpu_lock:
+                        res = engine.process_frame(
+                            img,
+                            mask,
+                            input_is_linear=is_linear,
+                            fg_is_straight=True,
+                            despill_strength=params.despill_strength,
+                            auto_despeckle=params.auto_despeckle,
+                            despeckle_size=params.despeckle_size,
+                            despeckle_dilation=params.despeckle_dilation,
+                            despeckle_blur=params.despeckle_blur,
+                            refiner_scale=params.refiner_scale,
+                        )
+                    logger.debug(f"Clip '{clip.name}' frame {i}: process_frame {time.monotonic() - t_frame:.3f}s")
+
+                    # Write outputs
+                    self._write_outputs(res, dirs, input_stem, clip.name, i, cfg)
+                    results.append(FrameResult(i, input_stem, True))
+
+                except FrameReadError as e:
+                    logger.warning(str(e))
+                    skipped.append(i)
+                    results.append(FrameResult(i, f"{i:05d}", False, str(e)))
+                    if on_warning:
+                        on_warning(str(e))
+
+                except WriteFailureError as e:
+                    logger.error(str(e))
+                    results.append(FrameResult(i, f"{i:05d}", False, str(e)))
+                    if on_warning:
+                        on_warning(str(e))
+
+            # Final progress
+            if on_progress:
+                on_progress(clip.name, range_count, range_count)
+
+        finally:
+            if input_cap:
+                input_cap.release()
+            if alpha_cap:
+                alpha_cap.release()
+
+        # Summary
+        processed = sum(1 for r in results if r.success)
+        if skipped:
+            msg = (
+                f"Clip '{clip.name}': {len(skipped)} frame(s) skipped: "
+                f"{skipped[:20]}{'...' if len(skipped) > 20 else ''}"
+            )
+            logger.warning(msg)
+            if on_warning:
+                on_warning(msg)
+
+        t_total = time.monotonic() - t_start
+        range_label = f" (range {frame_range[0]}-{frame_range[1]})" if frame_range else ""
+        logger.info(
+            f"Clip '{clip.name}': inference complete{range_label}. {processed}/{range_count} frames "
+            f"in {t_total:.1f}s ({t_total / max(processed, 1):.2f}s/frame avg)"
+        )
+
+        # State transition — only set COMPLETE if full clip was processed
+        is_full_clip = frame_range is None or (frame_range[0] == 0 and frame_range[1] >= num_frames - 1)
+        if processed == range_count and is_full_clip:
+            try:
+                clip.transition_to(ClipState.COMPLETE)
+            except Exception as e:
+                logger.warning(f"Clip '{clip.name}': state transition to COMPLETE failed: {e}")
+
+        return results
+
+    # --- Single-Frame Reprocess (Preview) ---
+
+    def is_engine_loaded(self) -> bool:
+        """True if the inference engine is already loaded in VRAM."""
+        return self._active_model == _ActiveModel.INFERENCE and self._engine is not None
+
+    def reprocess_single_frame(
+        self,
+        clip: ClipEntry,
+        params: InferenceParams,
+        frame_index: int,
+        job: Optional[GPUJob] = None,
+    ) -> Optional[dict]:
+        """Reprocess a single frame with current params.
+
+        Returns the result dict (fg, alpha, comp, processed) or None.
+        This runs through the GPU lock for thread safety.
+        Does NOT write to disk — returns in-memory results for preview.
+        """
+        t_start = time.monotonic()
+        if clip.input_asset is None or clip.alpha_asset is None:
+            return None
+
+        if job and job.is_cancelled:
+            return None
+
+        with self._gpu_lock:
+            engine = self._get_engine()
+
+        # Read the specific input frame
+        if clip.input_asset.asset_type == "video":
+            img = read_video_frame_at(clip.input_asset.path, frame_index)
+        else:
+            input_files = clip.input_asset.get_frame_files()
+            if frame_index >= len(input_files):
+                return None
+            img = read_image_frame(os.path.join(clip.input_asset.path, input_files[frame_index]))
+        if img is None:
+            return None
+
+        # Read the specific alpha frame
+        if clip.alpha_asset.asset_type == "video":
+            mask = read_video_mask_at(clip.alpha_asset.path, frame_index)
+        else:
+            alpha_files = clip.alpha_asset.get_frame_files()
+            if frame_index >= len(alpha_files):
+                return None
+            mask = read_mask_frame(
+                os.path.join(clip.alpha_asset.path, alpha_files[frame_index]),
+                clip.name,
+                frame_index,
+            )
+        if mask is None:
+            return None
+
+        if mask.shape[:2] != img.shape[:2]:
+            mask = cv2.resize(mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR)
+
+        if job and job.is_cancelled:
+            return None
+
+        with self._gpu_lock:
+            res = engine.process_frame(
+                img,
+                mask,
+                input_is_linear=params.input_is_linear,
+                fg_is_straight=True,
+                despill_strength=params.despill_strength,
+                auto_despeckle=params.auto_despeckle,
+                despeckle_size=params.despeckle_size,
+                despeckle_dilation=params.despeckle_dilation,
+                despeckle_blur=params.despeckle_blur,
+                refiner_scale=params.refiner_scale,
+            )
+        logger.debug(f"Clip '{clip.name}' frame {frame_index}: reprocess {time.monotonic() - t_start:.3f}s")
+        return res
+
+    # --- GVM Alpha Generation ---
+
+    def run_gvm(
+        self,
+        clip: ClipEntry,
+        job: Optional[GPUJob] = None,
+        on_progress: Optional[Callable[[str, int, int], None]] = None,
+        on_warning: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        """Run GVM auto alpha generation for a clip.
+
+        Transitions clip: RAW → READY (creates AlphaHint directory).
+
+        Args:
+            clip: Must be in RAW state with input_asset.
+            job: Optional GPUJob for cancel checking.
+            on_progress: Progress callback (GVM is monolithic, reports start/end).
+            on_warning: Warning callback.
+        """
+        if clip.input_asset is None:
+            raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for GVM")
+
+        t_start = time.monotonic()
+
+        with self._gpu_lock:
+            gvm = self._get_gvm()
+
+        alpha_dir = os.path.join(clip.root_path, "AlphaHint")
+        os.makedirs(alpha_dir, exist_ok=True)
+
+        if on_progress:
+            on_progress(clip.name, 0, 1)
+
+        # Check cancel before starting
+        if job and job.is_cancelled:
+            raise JobCancelledError(clip.name, 0)
+
+        # Per-batch progress callback — GVM iterates over frames internally
+        def _gvm_progress(batch_idx: int, total_batches: int) -> None:
+            if on_progress:
+                on_progress(clip.name, batch_idx, total_batches)
+            # Check cancel between batches
+            if job and job.is_cancelled:
+                raise JobCancelledError(clip.name, batch_idx)
+
+        try:
+            gvm.process_sequence(
+                input_path=clip.input_asset.path,
+                output_dir=clip.root_path,
+                num_frames_per_batch=1,
+                decode_chunk_size=1,
+                denoise_steps=1,
+                mode="matte",
+                write_video=False,
+                direct_output_dir=alpha_dir,
+                progress_callback=_gvm_progress,
+            )
+        except JobCancelledError:
+            raise
+        except Exception as e:
+            if job and job.is_cancelled:
+                raise JobCancelledError(clip.name, 0) from None
+            raise CorridorKeyError(f"GVM failed for '{clip.name}': {e}") from e
+
+        # Refresh alpha asset
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
+
+        if on_progress:
+            on_progress(clip.name, 1, 1)
+
+        # Transition RAW → READY
+        try:
+            clip.transition_to(ClipState.READY)
+        except Exception as e:
+            if on_warning:
+                on_warning(f"State transition after GVM: {e}")
+
+        elapsed = time.monotonic() - t_start
+        logger.info(f"GVM complete for '{clip.name}': {clip.alpha_asset.frame_count} alpha frames in {elapsed:.1f}s")
+
+    # --- VideoMaMa Alpha Generation ---
+
+    def run_videomama(
+        self,
+        clip: ClipEntry,
+        job: Optional[GPUJob] = None,
+        on_progress: Optional[Callable[[str, int, int], None]] = None,
+        on_warning: Optional[Callable[[str], None]] = None,
+        on_status: Optional[Callable[[str], None]] = None,
+        chunk_size: int = 50,
+    ) -> None:
+        """Run VideoMaMa guided alpha generation for a clip.
+
+        Transitions clip: MASKED → READY (creates AlphaHint directory).
+
+        Args:
+            clip: Must be in MASKED state with input_asset and mask_asset.
+            job: Optional GPUJob for cancel checking.
+            on_progress: Progress callback with per-chunk updates.
+            on_warning: Warning callback.
+            on_status: Phase status callback (e.g. "Loading model...").
+            chunk_size: Frames per chunk (lower = less RAM, default 50).
+        """
+        if clip.input_asset is None:
+            raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for VideoMaMa")
+        if clip.mask_asset is None:
+            raise CorridorKeyError(f"Clip '{clip.name}' missing mask asset for VideoMaMa")
+
+        def _status(msg: str) -> None:
+            logger.info(f"VideoMaMa [{clip.name}]: {msg}")
+            if on_status:
+                on_status(msg)
+
+        def _check_cancel(phase: str = "") -> None:
+            if job and job.is_cancelled:
+                raise JobCancelledError(clip.name, 0)
+
+        t_start = time.monotonic()
+
+        # ── Phase 1: Load model ──
+        _status("Loading model...")
+        with self._gpu_lock:
+            pipeline = self._get_videomama_pipeline()
+        _check_cancel("model load")
+
+        alpha_dir = os.path.join(clip.root_path, "AlphaHint")
+        os.makedirs(alpha_dir, exist_ok=True)
+
+        # Don't report progress yet — phase status is showing in the status bar.
+        # Sending on_progress(0, N) would switch the status bar to frame-counter
+        # mode and overwrite the phase text on every tick.
+
+        # ── Phase 2: Load input frames ──
+        _status("Loading frames...")
+        input_frames = self._load_frames_for_videomama(
+            clip.input_asset,
+            clip.name,
+            job=job,
+            on_status=on_status,
+        )
+        _check_cancel("frame load")
+
+        # ── Phase 3: Load + stem-match masks ──
+        _status("Loading masks...")
+        mask_stems: dict[str, np.ndarray] = {}
+        if clip.mask_asset.asset_type == "sequence":
+            mask_files = clip.mask_asset.get_frame_files()
+            for _i, fname in enumerate(mask_files):
+                _check_cancel("mask load")
+                fpath = os.path.join(clip.mask_asset.path, fname)
+                m = cv2.imread(fpath, cv2.IMREAD_GRAYSCALE)
+                if m is not None:
+                    _, binary = cv2.threshold(m, 10, 255, cv2.THRESH_BINARY)
+                    stem = os.path.splitext(fname)[0]
+                    mask_stems[stem] = binary
+        else:
+            raw_masks = self._load_mask_frames_for_videomama(clip.mask_asset, clip.name)
+            for i, m in enumerate(raw_masks):
+                mask_stems[f"frame_{i:06d}"] = m
+
+        # Build output filenames from input stems
+        if clip.input_asset and clip.input_asset.asset_type == "sequence":
+            input_names = clip.input_asset.get_frame_files()
+        else:
+            input_names = [f"frame_{i:06d}.png" for i in range(len(input_frames))]
+
+        # Align masks to input frames by stem, defaulting to all-black
+        num_frames = len(input_frames)
+        mask_frames = []
+        for fname in input_names:
+            stem = os.path.splitext(fname)[0]
+            if stem in mask_stems:
+                mask_frames.append(mask_stems[stem])
+            else:
+                h_m, w_m = input_frames[0].shape[:2] if input_frames else (4, 4)
+                mask_frames.append(np.zeros((h_m, w_m), dtype=np.uint8))
+
+        # ── Resume logic ──
+        existing_alpha = []
+        if os.path.isdir(alpha_dir):
+            existing_alpha = [f for f in os.listdir(alpha_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+        n_existing = len(existing_alpha)
+        completed_chunks = n_existing // chunk_size
+        start_chunk = max(0, completed_chunks - 1)
+        start_frame = start_chunk * chunk_size
+        if start_frame > 0:
+            keep = set()
+            for i in range(start_frame):
+                if i < len(input_names):
+                    stem = os.path.splitext(input_names[i])[0]
+                    keep.add(f"{stem}.png")
+            for fname in existing_alpha:
+                if fname not in keep:
+                    os.remove(os.path.join(alpha_dir, fname))
+            logger.info(
+                f"VideoMaMa resuming for '{clip.name}': {n_existing} alpha frames existed, "
+                f"rolling back to chunk {start_chunk} (frame {start_frame})"
+            )
+
+        # ── Phase 4: Inference (per-chunk) ──
+        sys.path.insert(0, os.path.join(BASE_DIR, "VideoMaMaInferenceModule"))
+        from VideoMaMaInferenceModule.inference import run_inference
+
+        total_chunks = (num_frames + chunk_size - 1) // chunk_size
+        _status(f"Running inference (chunk 1/{total_chunks})...")
+        frames_written = start_frame
+        for chunk_idx, chunk_output in enumerate(
+            run_inference(pipeline, input_frames, mask_frames, chunk_size=chunk_size)
+        ):
+            _check_cancel("inference")
+
+            # Skip already-completed chunks (resume)
+            if chunk_idx < start_chunk:
+                frames_written += len(chunk_output)
+                if on_progress:
+                    on_progress(clip.name, frames_written, num_frames)
+                continue
+
+            _status(f"Processing chunk {chunk_idx + 1}/{total_chunks}...")
+
+            # Write chunk frames
+            t_chunk = time.monotonic()
+            for frame in chunk_output:
+                out_bgr = cv2.cvtColor(
+                    (np.clip(frame, 0.0, 1.0) * 255.0).astype(np.uint8),
+                    cv2.COLOR_RGB2BGR,
+                )
+                if frames_written < len(input_names):
+                    stem = os.path.splitext(input_names[frames_written])[0]
+                    out_name = f"{stem}.png"
+                else:
+                    out_name = f"frame_{frames_written:06d}.png"
+                out_path = os.path.join(alpha_dir, out_name)
+                cv2.imwrite(out_path, out_bgr)
+                frames_written += 1
+            chunk_elapsed = time.monotonic() - t_chunk
+            logger.debug(f"Clip '{clip.name}' chunk {chunk_idx}: {len(chunk_output)} frames in {chunk_elapsed:.3f}s")
+
+            if on_progress:
+                on_progress(clip.name, frames_written, num_frames)
+
+        # Refresh alpha asset
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
+
+        # Transition MASKED → READY
+        try:
+            clip.transition_to(ClipState.READY)
+        except Exception as e:
+            if on_warning:
+                on_warning(f"State transition after VideoMaMa: {e}")
+
+        elapsed = time.monotonic() - t_start
+        logger.info(f"VideoMaMa complete for '{clip.name}': {frames_written} alpha frames in {elapsed:.1f}s")
+
+    def _load_frames_for_videomama(
+        self,
+        asset: ClipAsset,
+        clip_name: str,
+        job: Optional[GPUJob] = None,
+        on_status: Optional[Callable[[str], None]] = None,
+    ) -> list[np.ndarray]:
+        """Load input frames for VideoMaMa as uint8 RGB [0, 255].
+
+        The VideoMaMa inference code expects uint8 arrays for PIL conversion.
+        Reports loading progress via on_status and checks cancel via job.
+        """
+        if asset.asset_type == "video":
+            raw = read_video_frames(asset.path)
+            return [(np.clip(f, 0.0, 1.0) * 255.0).astype(np.uint8) for f in raw]
+        frames = []
+        files = asset.get_frame_files()
+        total = len(files)
+        for i, fname in enumerate(files):
+            if job and job.is_cancelled:
+                from .errors import JobCancelledError
+
+                raise JobCancelledError(clip_name, i)
+            fpath = os.path.join(asset.path, fname)
+            img = read_image_frame(fpath, gamma_correct_exr=True)
+            if img is not None:
+                frames.append((np.clip(img, 0.0, 1.0) * 255.0).astype(np.uint8))
+            if on_status and i % 20 == 0 and i > 0:
+                on_status(f"Loading frames ({i}/{total})...")
+        return frames
+
+    def _load_mask_frames_for_videomama(self, asset: ClipAsset, clip_name: str) -> list[np.ndarray]:
+        """Load mask frames for VideoMaMa as uint8 grayscale [0, 255].
+
+        The VideoMaMa inference code expects uint8 arrays for PIL conversion.
+        Binary threshold at 10: anything above → 255 (foreground), else → 0.
+        """
+
+        def _threshold_mask(bgr_frame: np.ndarray) -> np.ndarray:
+            gray = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2GRAY)
+            _, binary = cv2.threshold(gray, 10, 255, cv2.THRESH_BINARY)
+            return binary  # uint8
+
+        if asset.asset_type == "video":
+            return read_video_frames(asset.path, processor=_threshold_mask)
+        masks = []
+        for fname in asset.get_frame_files():
+            fpath = os.path.join(asset.path, fname)
+            mask = cv2.imread(fpath, cv2.IMREAD_GRAYSCALE)
+            if mask is None:
+                continue
+            _, binary = cv2.threshold(mask, 10, 255, cv2.THRESH_BINARY)
+            masks.append(binary)  # uint8
+        return masks

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -1,0 +1,159 @@
+"""Validation utilities for frame processing.
+
+All validators either return cleaned data or raise typed exceptions from errors.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import numpy as np
+
+from .errors import (
+    FrameMismatchError,
+    FrameReadError,
+    MaskChannelError,
+    WriteFailureError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def validate_frame_counts(
+    clip_name: str,
+    input_count: int,
+    alpha_count: int,
+    strict: bool = False,
+) -> int:
+    """Validate that input and alpha frame counts are compatible.
+
+    Args:
+        clip_name: For error messages.
+        input_count: Number of input frames.
+        alpha_count: Number of alpha frames.
+        strict: If True, raises on mismatch. If False, logs warning and returns min.
+
+    Returns:
+        The number of frames to process (min of both).
+
+    Raises:
+        FrameMismatchError: If strict=True and counts differ.
+    """
+    if input_count != alpha_count:
+        if strict:
+            raise FrameMismatchError(clip_name, input_count, alpha_count)
+        logger.warning(
+            f"Clip '{clip_name}': frame count mismatch — "
+            f"input has {input_count}, alpha has {alpha_count}. "
+            f"Truncating to {min(input_count, alpha_count)}."
+        )
+    return min(input_count, alpha_count)
+
+
+def normalize_mask_channels(
+    mask: np.ndarray,
+    clip_name: str = "",
+    frame_index: int = 0,
+) -> np.ndarray:
+    """Reduce a mask to a single-channel 2D array.
+
+    Handles any channel count: extracts first channel from multi-channel masks.
+
+    Args:
+        mask: Input mask array, any shape [H, W] or [H, W, C].
+        clip_name: For error messages.
+        frame_index: For error messages.
+
+    Returns:
+        2D numpy array [H, W] with float32 values.
+    """
+    if mask.ndim == 3:
+        if mask.shape[2] == 0:
+            raise MaskChannelError(clip_name, frame_index, 0)
+        # Always extract first channel regardless of channel count
+        mask = mask[:, :, 0]
+    elif mask.ndim != 2:
+        raise MaskChannelError(clip_name, frame_index, mask.ndim)
+
+    return mask.astype(np.float32) if mask.dtype != np.float32 else mask
+
+
+def normalize_mask_dtype(mask: np.ndarray) -> np.ndarray:
+    """Convert mask to float32 [0.0, 1.0] from any common dtype."""
+    if mask.dtype == np.uint8:
+        return mask.astype(np.float32) / 255.0
+    elif mask.dtype == np.uint16:
+        return mask.astype(np.float32) / 65535.0
+    elif mask.dtype == np.float64:
+        return mask.astype(np.float32)
+    elif mask.dtype == np.float32:
+        return mask
+    else:
+        return mask.astype(np.float32)
+
+
+def validate_frame_read(
+    frame: Optional[np.ndarray],
+    clip_name: str,
+    frame_index: int,
+    path: str,
+) -> np.ndarray:
+    """Validate that a frame was read successfully.
+
+    Args:
+        frame: The result of cv2.imread() — None if read failed.
+        clip_name: For error messages.
+        frame_index: For error messages.
+        path: File path that was read.
+
+    Returns:
+        The frame array (unchanged).
+
+    Raises:
+        FrameReadError: If frame is None.
+    """
+    if frame is None:
+        raise FrameReadError(clip_name, frame_index, path)
+    return frame
+
+
+def validate_write(
+    success: bool,
+    clip_name: str,
+    frame_index: int,
+    path: str,
+) -> None:
+    """Validate that a cv2.imwrite() call succeeded.
+
+    Args:
+        success: Return value of cv2.imwrite().
+        clip_name: For error messages.
+        frame_index: For error messages.
+        path: File path that was written.
+
+    Raises:
+        WriteFailureError: If success is False.
+    """
+    if not success:
+        raise WriteFailureError(clip_name, frame_index, path)
+
+
+def ensure_output_dirs(clip_root: str) -> dict[str, str]:
+    """Create output subdirectories for a clip and return their paths.
+
+    Returns:
+        Dict with keys: 'root', 'fg', 'matte', 'comp', 'processed'
+    """
+    out_root = os.path.join(clip_root, "Output")
+    dirs = {
+        "root": out_root,
+        "fg": os.path.join(out_root, "FG"),
+        "matte": os.path.join(out_root, "Matte"),
+        "comp": os.path.join(out_root, "Comp"),
+        "processed": os.path.join(out_root, "Processed"),
+    }
+    for d in dirs.values():
+        os.makedirs(d, exist_ok=True)
+    return dirs


### PR DESCRIPTION
## Summary

Introduces a `backend/` package that provides a clean API layer between the CorridorKey inference engine and external frontends (GUI, CLI, API). This is **100% additive** — no existing upstream files are modified.

### What it does

- **Service facade** (`service.py`) — wraps inference, GVM, and VideoMaMa into a single `CorridorKeyService` class with scan → validate → process → write workflow
- **Clip state machine** (`clip_state.py`) — models clip lifecycle (RAW → READY → COMPLETE) with automatic asset detection
- **Job queue** (`job_queue.py`) — priority-based GPU job scheduling with cancel support and progress callbacks
- **Project management** (`project.py`) — timestamped project folders, JSON metadata, clip import from video/image sequences
- **Frame I/O** (`frame_io.py`) — unified reader for PNG/EXR/video with consistent float32 RGB output
- **FFmpeg tools** (`ffmpeg_tools.py`) — video probing, frame extraction with resume, video stitching
- **Validators** (`validators.py`) — frame count validation, read/write verification, output directory scaffolding
- **Error hierarchy** (`errors.py`) — typed exceptions inheriting from `CorridorKeyError`

### Why

I'm building [EZ-CorridorKey-GUI](https://github.com/edenaion/EZ-CorridorKey-GUI), a PySide6 desktop frontend for CorridorKey. This backend layer provides a clean separation: the GUI calls `backend/` methods, the backend calls the inference engines. The engine code stays untouched.

This also benefits anyone building a CLI tool, API server, or other frontend — they get a ready-made service layer instead of wiring directly into the inference modules.

### Integration with upstream

- Uses `device_utils.resolve_device()` and `clear_device_cache()` for cross-platform GPU selection (CUDA/MPS/CPU)
- Single-model VRAM residency — only one heavy model loaded at a time, automatic unload/reload
- Thread-safe GPU mutex for concurrent job submissions
- All imports from existing modules use their current public API

### Quality

- Passes `ruff check` and `ruff format` (E, F, W, I, B rules, 120 char line length)
- No modifications to existing files
- Test suite for this backend will follow as a separate PR

## Test plan

- [x] `ruff check backend/` — all checks passed
- [x] `ruff format --check backend/` — all files formatted
- [x] Existing upstream tests still pass (145/145, excluding pre-existing Windows path separator issues in `test_clip_manager.py::TestMapPath`)
- [x] `from backend import CorridorKeyService` imports cleanly
- [ ] Backend test suite (separate PR)