### PR TITLE
Fixes #42: test_clip_manager test failure

### DIFF
--- a/clip_manager.py
+++ b/clip_manager.py
@@ -54,10 +54,8 @@ def map_path(win_path: str) -> str:
     if win_path.upper().startswith(WIN_DRIVE_ROOT.upper()):
         # Remove drive letter
         rel_path = win_path[len(WIN_DRIVE_ROOT) :]
-        # Flip slashes
-        rel_path = rel_path.replace("\\", "/")
-        # Combine
-        linux_path = os.path.join(LINUX_MOUNT_ROOT, rel_path)
+        # Combine and flip slashes
+        linux_path = os.path.join(LINUX_MOUNT_ROOT, rel_path).replace("\\", "/")
         return linux_path
 
     # If not on V:, maybe it's already a linux path or invalid?


### PR DESCRIPTION
## What does this change?
Fix failing unit test. Fixes https://github.com/nikopueringer/CorridorKey/issues/42.

## How was it tested?
`uv run pytest --cov=CorridorKeyModule --cov-branch`

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes