### PR TITLE
Update MLX repo URL to https://github.com/nikopueringer/corridorkey-mlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Auto mode prefers MLX on Apple Silicon when available.
 
 1. Install the MLX backend:
    ```bash
-   uv pip install corridorkey-mlx@git+https://github.com/cmoyates/corridorkey-mlx.git
+   uv pip install corridorkey-mlx@git+https://github.com/nikopueringer/corridorkey-mlx.git
    ```
 2. Place converted weights in `CorridorKeyModule/checkpoints/`:
    ```
@@ -169,7 +169,7 @@ MLX uses img_size=2048 by default (same as Torch).
 
 ### Troubleshooting
 - **"No .safetensors checkpoint found"** — place MLX weights in `CorridorKeyModule/checkpoints/`
-- **"corridorkey_mlx not installed"** — run `uv pip install corridorkey-mlx@git+https://github.com/cmoyates/corridorkey-mlx.git`
+- **"corridorkey_mlx not installed"** — run `uv pip install corridorkey-mlx@git+https://github.com/nikopueringer/corridorkey-mlx.git`
 - **"MLX requires Apple Silicon"** — MLX only works on M1+ Macs
 - **Auto picked Torch unexpectedly** — set `CORRIDORKEY_BACKEND=mlx` explicitly
 


### PR DESCRIPTION
## Summary
- Update corridorkey-mlx install URLs in README from `cmoyates/corridorkey-mlx` to `nikopueringer/corridorkey-mlx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)