### PR TITLE
Fix #15: Add uv check to launcher scripts

### DIFF
--- a/CorridorKey_DRAG_CLIPS_HERE_local.bat
+++ b/CorridorKey_DRAG_CLIPS_HERE_local.bat
@@ -1,6 +1,14 @@
 @echo off
 REM Corridor Key Launcher - Local
 
+REM Check for uv
+where uv >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] uv is not installed. Please run Install_CorridorKey_Windows.bat first.
+    pause
+    exit /b
+)
+
 REM Set script path (assumes corridorkey_cli.py is in the same directory as this batch file)
 set "SCRIPT_DIR=%~dp0"
 set "LOCAL_SCRIPT=%SCRIPT_DIR%corridorkey_cli.py"

--- a/CorridorKey_DRAG_CLIPS_HERE_local.sh
+++ b/CorridorKey_DRAG_CLIPS_HERE_local.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Corridor Key Launcher - Local Linux/macOS
 
+# Check for uv
+if ! command -v uv &> /dev/null; then
+    echo "[ERROR] uv not installed. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
 # Get the directory where this script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 LOCAL_SCRIPT="$SCRIPT_DIR/corridorkey_cli.py"

--- a/RunGVMOnly.sh
+++ b/RunGVMOnly.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check for uv
+if ! command -v uv &> /dev/null; then
+    echo "[ERROR] uv not installed. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
 # Ensure script stops on error
 set -e
 

--- a/RunInferenceOnly.sh
+++ b/RunInferenceOnly.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check for uv
+if ! command -v uv &> /dev/null; then
+    echo "[ERROR] uv not installed. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
 # Ensure script stops on error
 set -e
 

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -54,7 +54,7 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
 
     # 1. Resolve Path
     print(f"Windows Path: {win_path}")
-    
+
     # Check if we are running locally where the Windows path exists
     if os.path.exists(win_path):
         process_path = win_path
@@ -87,7 +87,9 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
     else:
         # Scan subfolders
         work_dirs = [
-            os.path.join(process_path, d) for d in os.listdir(process_path) if os.path.isdir(os.path.join(process_path, d))
+            os.path.join(process_path, d)
+            for d in os.listdir(process_path)
+            if os.path.isdir(os.path.join(process_path, d))
         ]
         # Filter out output/hints
         work_dirs = [


### PR DESCRIPTION
## Summary
- Add `uv` availability guard to all launcher scripts (3 `.sh`, 1 `.bat`)
- Scripts now exit early with a helpful error message if `uv` is not installed

**Note:** Untested — `.bat` script cannot be verified on macOS. Shell scripts follow standard `command -v` pattern.

Closes #15

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>