### PR TITLE
Fix #18: Replace print() with logging

### DIFF
--- a/CorridorKeyModule/core/model_transformer.py
+++ b/CorridorKeyModule/core/model_transformer.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
+
 import timm
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
 
 
 class MLP(nn.Module):
@@ -152,12 +156,12 @@ class GreenFormer(nn.Module):
         # Load Pretrained Hiera
         # 1. Create Target Model (512x512, Random Weights)
         # We use features_only=True, which wraps it in FeatureGetterNet
-        print(f"Initializing {encoder_name} (img_size={img_size})...")
+        logger.info("Initializing %s (img_size=%d)...", encoder_name, img_size)
         self.encoder = timm.create_model(encoder_name, pretrained=False, features_only=True, img_size=img_size)
         # We skip downloading/loading base weights because the user's checkpoint
         # (loaded immediately after this) contains all weights, including correctly
         # trained/sized PosEmbeds. This keeps the project offline-capable using only local assets.
-        print("Skipped downloading base weights (relying on custom checkpoint).")
+        logger.info("Skipped downloading base weights (relying on custom checkpoint).")
 
         # Patch First Layer for 4 channels
         if in_channels != 3:
@@ -170,7 +174,7 @@ class GreenFormer(nn.Module):
             feature_channels = self.encoder.feature_info.channels()
         except (AttributeError, TypeError):
             feature_channels = [112, 224, 448, 896]
-        print(f"Feature Channels: {feature_channels}")
+        logger.info("Feature Channels: %s", feature_channels)
 
         # --- Decoders ---
         embedding_dim = 256
@@ -189,7 +193,7 @@ class GreenFormer(nn.Module):
             self.refiner = CNNRefinerModule(in_channels=7, hidden_channels=64, out_channels=4)
         else:
             self.refiner = None
-            print("Refiner Module DISABLED (Backbone Only Mode).")
+            logger.info("Refiner Module DISABLED (Backbone Only Mode).")
 
     def _patch_input_layer(self, in_channels: int) -> None:
         """
@@ -233,7 +237,7 @@ class GreenFormer(nn.Module):
         except AttributeError:
             self.encoder.patch_embed.proj = new_conv
 
-        print(f"Patched input layer: 3 channels -> {in_channels} channels (Extra initialized to 0)")
+        logger.info("Patched input layer: 3 channels -> %d channels (Extra initialized to 0)", in_channels)
 
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         # x: [B, 4, H, W]

--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import os
 
@@ -10,6 +11,8 @@ import torch.nn.functional as F
 
 from .core import color_utils as cu
 from .core.model_transformer import GreenFormer
+
+logger = logging.getLogger(__name__)
 
 
 class CorridorKeyEngine:
@@ -27,7 +30,7 @@ class CorridorKeyEngine:
         self.model = self._load_model()
 
     def _load_model(self) -> GreenFormer:
-        print(f"Loading CorridorKey from {self.checkpoint_path}...")
+        logger.info("Loading CorridorKey from %s...", self.checkpoint_path)
         # Initialize Model (Hiera Backbone)
         model = GreenFormer(
             encoder_name="hiera_base_plus_224.mae_in1k_ft_in1k", img_size=self.img_size, use_refiner=self.use_refiner
@@ -53,7 +56,7 @@ class CorridorKeyEngine:
             # Check for PosEmbed Mismatch
             if "pos_embed" in k and k in model_state:
                 if v.shape != model_state[k].shape:
-                    print(f"Resizing {k} from {v.shape} to {model_state[k].shape}")
+                    logger.info("Resizing %s from %s to %s", k, v.shape, model_state[k].shape)
                     # v: [1, N_src, C]
                     # target: [1, N_dst, C]
                     # We assume square grid
@@ -77,9 +80,9 @@ class CorridorKeyEngine:
 
         missing, unexpected = model.load_state_dict(new_state_dict, strict=False)
         if len(missing) > 0:
-            print(f"[Warning] Missing keys: {missing}")
+            logger.warning("Missing keys: %s", missing)
         if len(unexpected) > 0:
-            print(f"[Warning] Unexpected keys: {unexpected}")
+            logger.warning("Unexpected keys: %s", unexpected)
 
         return model
 

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -54,7 +54,7 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
 
     # 1. Resolve Path
     print(f"Windows Path: {win_path}")
-    
+
     # Check if we are running locally where the Windows path exists
     if os.path.exists(win_path):
         process_path = win_path
@@ -87,7 +87,9 @@ def interactive_wizard(win_path: str, device: str | None = None) -> None:
     else:
         # Scan subfolders
         work_dirs = [
-            os.path.join(process_path, d) for d in os.listdir(process_path) if os.path.isdir(os.path.join(process_path, d))
+            os.path.join(process_path, d)
+            for d in os.listdir(process_path)
+            if os.path.isdir(os.path.join(process_path, d))
         ]
         # Filter out output/hints
         work_dirs = [


### PR DESCRIPTION
## Summary
- Add `logger = logging.getLogger(__name__)` to `inference_engine.py` and `model_transformer.py`
- Replace all `print()` calls with appropriate `logger.info()` / `logger.warning()` calls
- 9 print statements replaced across both files

**Note:** Untested — checkpoint loading paths are mocked in unit tests. Verified lint/format pass.

Closes #18

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>