### PR TITLE
chore: Freeze dependency installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --frozen
 
       - name: Check formatting
         run: uv run ruff format --check
@@ -40,7 +40,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group dev --python ${{ matrix.python-version }}
+        run: uv sync --group dev --python ${{ matrix.python-version }}  --frozen
 
       - name: Run tests
         run: uv run pytest -v --tb=short -m "not gpu"


### PR DESCRIPTION
## What does this change?

Freezes dependencies in CI based on the current `uv.lock` file. This is standard practice to ensure runs are reproducible and notably to lower the attack surface for unexpected supply chain attacks.

Read more: https://medium.com/dev-simplified/frozen-lockfile-in-projects-why-you-shouldnt-ignore-it-2d6b7a9ebf2e

## How was it tested?

Not applicable.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
