### PR TITLE
chore: Enforce semantic PR titles

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,20 @@
+name: Pull Request Checks
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Check Semantic Pr Title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

This adds a light CI step ran every time a pull request is edited. This needs to be separate from ci.yml because it runs when the content of the pull request gets updated as well, not only the associated commits.

It makes sure pull request titles follow the Conventional Commits standard and as such are more readable and follow open standards. Read more: https://www.conventionalcommits.org/en/v1.0.0/

## How was it tested?

Not Applicable.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
