### PR TITLE
fix: skip cu126 PyTorch index on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,5 +92,5 @@ url = "https://download.pytorch.org/whl/cu126"
 explicit = true
 
 [tool.uv.sources]
-torch = { index = "pytorch" }
-torchvision = { index = "pytorch" }
+torch = { index = "pytorch", marker = "sys_platform != 'darwin'" }
+torchvision = { index = "pytorch", marker = "sys_platform != 'darwin'" }


### PR DESCRIPTION
## Summary

- Add `sys_platform != 'darwin'` marker to `torch` and `torchvision` uv sources

## Why

Without the platform marker, `uv sync` on macOS tries to pull wheels from the cu126 (CUDA-only) PyTorch index. These wheels don't include MPS support and can fail to install entirely on Apple Silicon. Adding the marker lets macOS fall through to PyPI, which serves the standard wheels with MPS backend support.

Linux/Windows behavior is unchanged — they still pull from the cu126 index as before.

## Test plan

- [ ] `uv sync` on macOS installs torch from PyPI (MPS-compatible)
- [ ] `uv sync` on Linux still installs torch from cu126 index
- [ ] `uv run pytest` passes on both platforms


🤖 Generated with [Claude Code](https://claude.com/claude-code)