### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/CorridorKey_DRAG_CLIPS_HERE_local.sh
+++ b/CorridorKey_DRAG_CLIPS_HERE_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Corridor Key Launcher - Local Linux/macOS
 
 # Get the directory where this script is located

--- a/RunGVMOnly.sh
+++ b/RunGVMOnly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ensure script stops on error
 set -e

--- a/RunInferenceOnly.sh
+++ b/RunInferenceOnly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ensure script stops on error
 set -e


### PR DESCRIPTION
Replace `#!/bin/bash` with `#!/usr/bin/env bash` in bash scripts.

On macOS, /bin/bash points to an outdated version (3.2) due to licensing. Most users install a newer bash (e.g. via Homebrew) in a non-standard location. Using /usr/bin/env bash finds the first bash in PATH, so scripts use the user's preferred installation.

On Linux and other Unix systems, /usr/bin/env is widely available and avoids hardcoding /bin/bash. Bash can live in different paths (e.g. /usr/local/bin on OpenBSD). Using env improves portability for scripts shared across environments.

Reference: Dave - Why I Don't Use #!/bin/bash - Shebangs Explained! https://www.youtube.com/watch?v=aoHMiCzqCNw