### PR TITLE
improve: Mac UX — uv check, platform FFmpeg hint, --backend flag, os.path.join, MPS docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,29 @@ uv run pytest --cov        # show test coverage (sources and branch mode configu
 
 Most tests run in a few seconds and don't need a GPU or model weights. Tests that require CUDA are marked with `@pytest.mark.gpu` and will be skipped automatically if no GPU is available.
 
+### Apple Silicon (Mac) Notes
+
+If you are contributing on an Apple Silicon Mac, there are a few extra things to be aware of.
+
+**`uv.lock` drift:** Running `uv run pytest` on macOS regenerates `uv.lock` with macOS-specific dependency markers. **Do not commit this file.** Before staging your changes, always run:
+
+```bash
+git restore uv.lock
+```
+
+**Selecting the compute backend:** CorridorKey auto-detects MPS on Apple Silicon. To test with the MLX backend or force CPU, set the environment variable before running:
+
+```bash
+export CORRIDORKEY_BACKEND=mlx   # use native MLX on Apple Silicon
+export CORRIDORKEY_DEVICE=cpu    # force CPU (useful for isolating device bugs)
+```
+
+**MPS operator fallback:** If PyTorch raises an error about an unsupported MPS operator, enable CPU fallback for those ops:
+
+```bash
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+```
+
 ### Linting and Formatting
 
 ```bash

--- a/CorridorKey_DRAG_CLIPS_HERE_local.sh
+++ b/CorridorKey_DRAG_CLIPS_HERE_local.sh
@@ -26,6 +26,18 @@ TARGET_PATH="$1"
 # Strip trailing slash if present
 TARGET_PATH="${TARGET_PATH%/}"
 
+# Ensure uv is available before attempting to run
+if ! command -v uv &> /dev/null; then
+    echo "[ERROR] 'uv' is not installed or not on PATH."
+    echo ""
+    echo "Install uv by running:"
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo ""
+    echo "Then reopen your terminal and try again."
+    read -p "Press enter to exit..."
+    exit 1
+fi
+
 echo "Starting Corridor Key locally..."
 echo "Target: $TARGET_PATH"
 

--- a/README.md
+++ b/README.md
@@ -191,10 +191,22 @@ uv run python clip_manager.py --action wizard --win_path "V:\..."
 
 Priority: `--device` flag > `CORRIDORKEY_DEVICE` env var > auto-detect.
 
-**Mac users (Apple Silicon):** MPS support is experimental in PyTorch. If you encounter operator errors, set `PYTORCH_ENABLE_MPS_FALLBACK=1` to fall back to CPU for unsupported ops:
+### Apple Silicon / MPS Troubleshooting
+
+**Confirm MPS is active:** Run with verbose logging to see which device was selected:
+```bash
+uv run python clip_manager.py --action list 2>&1 | grep -i "device\|backend\|mps"
+```
+
+**MPS operator errors** (`NotImplementedError: ... not implemented for 'MPS'`): Some PyTorch operations are not yet supported on MPS. Enable CPU fallback for those ops:
 ```bash
 export PYTORCH_ENABLE_MPS_FALLBACK=1
+uv run python corridorkey_cli.py --action wizard --win_path "/path/to/clips"
 ```
+
+**Silent CPU fallback**: If MPS silently falls back to CPU without this variable, the run will be much slower. Setting `PYTORCH_ENABLE_MPS_FALLBACK=1` in your shell profile (`~/.zshrc`) ensures it is always active.
+
+**Use native MLX instead of PyTorch MPS:** MLX avoids PyTorch's MPS layer entirely and typically runs faster on Apple Silicon. See the [Backend Selection](#backend-selection) section below for setup steps.
 
 ## Backend Selection
 
@@ -204,6 +216,12 @@ CorridorKey supports two inference backends:
 
 Resolution: `--backend` flag > `CORRIDORKEY_BACKEND` env var > auto-detect.
 Auto mode prefers MLX on Apple Silicon when available.
+
+**Override via CLI flag (corridorkey_cli.py):**
+```bash
+uv run python corridorkey_cli.py --action wizard --win_path "/path/to/clips" --backend mlx
+uv run python corridorkey_cli.py --action run_inference --backend torch
+```
 
 ### MLX Setup (Apple Silicon)
 

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,5 +1,7 @@
 """Typed exceptions for the CorridorKey backend."""
 
+import sys
+
 
 class CorridorKeyError(Exception):
     """Base exception for all CorridorKey backend errors."""
@@ -88,9 +90,13 @@ class FFmpegNotFoundError(CorridorKeyError):
     """Raised when FFmpeg/FFprobe binaries cannot be located."""
 
     def __init__(self):
-        super().__init__(
-            "FFmpeg not found. Install FFmpeg and ensure it is on PATH, or place it in C:\\Program Files\\ffmpeg\\bin\\"
-        )
+        if sys.platform == "darwin":
+            hint = "Install FFmpeg via Homebrew: brew install ffmpeg"
+        elif sys.platform.startswith("linux"):
+            hint = "Install FFmpeg via your package manager: sudo apt install ffmpeg"
+        else:
+            hint = r"Place ffmpeg.exe in C:\Program Files\ffmpeg\bin\ or add it to PATH"
+        super().__init__(f"FFmpeg not found. {hint}")
 
 
 class ExtractionError(CorridorKeyError):

--- a/backend/ffmpeg_tools.py
+++ b/backend/ffmpeg_tools.py
@@ -202,7 +202,7 @@ def extract_frames(
             str(start_frame),
             "-vsync",
             "passthrough",
-            out_dir + "/" + pattern,
+            os.path.join(out_dir, pattern),
             "-y",
         ]
     else:
@@ -214,7 +214,7 @@ def extract_frames(
             "0",
             "-vsync",
             "passthrough",
-            out_dir + "/" + pattern,
+            os.path.join(out_dir, pattern),
             "-y",
         ]
 


### PR DESCRIPTION
## What changed

Six targeted improvements for Mac / Apple Silicon users, all in non-model files:

| File | Change |
|---|---|
| `CorridorKey_DRAG_CLIPS_HERE_local.sh` | Exit with install instructions if `uv` is not on PATH |
| `backend/errors.py` | `FFmpegNotFoundError` shows platform-specific hint (`brew` / `apt` / Windows path) |
| `corridorkey_cli.py` | Expose `--backend auto\|torch\|mlx` flag; wire through `interactive_wizard` and `run_inference` |
| `backend/ffmpeg_tools.py` | Replace `out_dir + "/" + pattern` string concat with `os.path.join()` at both call sites |
| `README.md` | Add Apple Silicon / MPS Troubleshooting subsection; document `--backend` CLI flag |
| `CONTRIBUTING.md` | Add Apple Silicon Notes: `uv.lock` drift warning, backend env vars, MPS fallback |

## Why

- New Mac users running the launcher script without `uv` installed got a cryptic `command not found` with no recovery path.
- `FFmpegNotFoundError` told everyone to install from `C:\Program Files\ffmpeg\bin\` regardless of platform.
- `corridorkey_cli.py` is the primary entry point but never exposed `--backend`, so Apple Silicon users couldn't select MLX without going through `clip_manager.py` directly or using the env var.
- `out_dir + "/" + pattern` is fragile on paths with trailing slashes; `os.path.join` is the correct idiom.
- The README had a single-line MPS note but no actionable troubleshooting for the two most common Apple Silicon failures.
- `CONTRIBUTING.md` was silent on the `uv.lock` regeneration issue that affects every Mac contributor.

## How to verify (no GPU or model weights required)

```bash
# Tests
uv run pytest                          # 171 passed, 1 skipped

# Lint / format
uv run ruff check backend/errors.py corridorkey_cli.py backend/ffmpeg_tools.py
uv run ruff format --check backend/errors.py corridorkey_cli.py backend/ffmpeg_tools.py

# --backend flag now appears in help
uv run python corridorkey_cli.py --help | grep -A3 backend

# No string concat remaining in ffmpeg_tools.py
grep 'out_dir.*"/"' backend/ffmpeg_tools.py   # should return nothing
```