### PR TITLE
fix: add defensive guards and logging for backend robustness

### DIFF
--- a/backend/clip_state.py
+++ b/backend/clip_state.py
@@ -86,6 +86,8 @@ class ClipAsset:
                 cap = cv2.VideoCapture(self.path)
                 if cap.isOpened():
                     self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                    if self.frame_count == 0:
+                        logger.warning(f"Video reports 0 frames, file may be corrupted: {self.path}")
                 cap.release()
             except Exception as e:
                 logger.debug(f"Video frame count detection failed for {self.path}: {e}")

--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -11,12 +11,15 @@ _load_frames_for_videomama, _load_mask_frames_for_videomama).
 
 from __future__ import annotations
 
+import logging
 from typing import Callable
 
 import cv2
 import numpy as np
 
 from .validators import normalize_mask_channels, normalize_mask_dtype
+
+logger = logging.getLogger(__name__)
 
 # EXR write flags — PXR24 half-float (smallest working compression)
 EXR_WRITE_FLAGS = [
@@ -43,6 +46,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> np.ndarray 
     if is_exr:
         img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
         if img is None:
+            logger.warning("Could not read frame: %s", fpath)
             return None
         # Strip alpha channel from BGRA EXR
         if img.ndim == 3 and img.shape[2] == 4:
@@ -55,6 +59,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> np.ndarray 
     else:
         img = cv2.imread(fpath)
         if img is None:
+            logger.warning("Could not read frame: %s", fpath)
             return None
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         return img_rgb.astype(np.float32) / 255.0

--- a/backend/service.py
+++ b/backend/service.py
@@ -289,7 +289,10 @@ class CorridorKeyService:
         if self._engine is not None:
             return self._engine
 
-        from CorridorKeyModule.inference_engine import CorridorKeyEngine
+        try:
+            from CorridorKeyModule.inference_engine import CorridorKeyEngine
+        except ImportError as exc:
+            raise RuntimeError("CorridorKeyModule is not installed. Run: uv sync") from exc
 
         ckpt_dir = os.path.join(BASE_DIR, "CorridorKeyModule", "checkpoints")
         ckpt_files = glob_module.glob(os.path.join(ckpt_dir, "*.pth"))
@@ -404,6 +407,11 @@ class CorridorKeyService:
             img_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             return img_rgb.astype(np.float32) / 255.0, input_stem, input_is_linear
         else:
+            if frame_index >= len(input_files):
+                logger.warning(
+                    f"Clip '{clip.name}': frame_index {frame_index} out of range (have {len(input_files)} frames)"
+                )
+                return None, f"{frame_index:05d}", input_is_linear
             fpath = os.path.join(clip.input_asset.path, input_files[frame_index])
             input_stem = os.path.splitext(input_files[frame_index])[0]
             img = read_image_frame(fpath)

--- a/device_utils.py
+++ b/device_utils.py
@@ -1,8 +1,11 @@
 """Centralized cross-platform device selection for CorridorKey."""
 
+import logging
 import os
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 DEVICE_ENV_VAR = "CORRIDORKEY_DEVICE"
 VALID_DEVICES = ("auto", "cuda", "mps", "cpu")
@@ -11,10 +14,13 @@ VALID_DEVICES = ("auto", "cuda", "mps", "cpu")
 def detect_best_device() -> str:
     """Auto-detect best available device: CUDA > MPS > CPU."""
     if torch.cuda.is_available():
-        return "cuda"
-    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        return "mps"
-    return "cpu"
+        device = "cuda"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
+    logger.info("Auto-selected device: %s", device)
+    return device
 
 
 def resolve_device(requested: str | None = None) -> str:


### PR DESCRIPTION
## What changed

Five surgical hardening changes across the backend:

1. **`_get_engine()` ImportError** (`backend/service.py`) — wraps the `CorridorKeyModule` import in `try/except ImportError` and raises a `RuntimeError` with a clear `uv sync` hint instead of an untracked `ImportError` crash.

2. **Zero-frame video warning** (`backend/clip_state.py`) — logs a `WARNING` when `cap.get(CAP_PROP_FRAME_COUNT)` returns 0 so users immediately see which file is likely corrupted rather than wondering why nothing was processed.

3. **`_read_input_frame()` bounds check** (`backend/service.py`) — guards `input_files[frame_index]` with a length check and returns `(None, stem, linear_flag)` + a `WARNING` log instead of raising an `IndexError` on short/corrupted sequences.

4. **`read_image_frame()` silent `None`** (`backend/frame_io.py`) — logs a `WARNING` with the file path when `cv2.imread()` returns `None`, so the silent failure becomes traceable without adding debug prints.

5. **`detect_best_device()` logging** (`device_utils.py`) — logs the auto-selected device at `INFO` level so users can confirm which compute backend was chosen.

## Why it was needed

Each of these sites previously failed silently or with an opaque Python exception, making it hard to diagnose environment issues (missing module, bad video, out-of-range frame, unreadable image, wrong device) from logs alone.

## How to verify

```bash
uv run pytest          # 171 passed, 1 skipped
uv run ruff check      # no errors
uv run ruff format --check  # all formatted
```

No GPU or model weights required.