### PR TITLE
test: add Batch C test coverage (despill, inference engine, E2E workflow)

### DIFF
--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -304,6 +304,20 @@ class TestDespill:
         result_t = cu.despill(img_t, green_limit_mode="average", strength=1.0)
         np.testing.assert_allclose(result_np, result_t.numpy(), atol=1e-5)
 
+    def test_green_below_limit_unchanged_numpy(self):
+        """spill_amount is clamped to zero when G < (R+B)/2 — pixel is returned unchanged.
+
+        When a pixel has less green than the luminance limit ((R+B)/2) it
+        carries no green spill.  The max(..., 0) clamp on spill_amount ensures
+        the pixel is left untouched.  Without that clamp despill would
+        *increase* green and *decrease* red/blue, corrupting non-spill regions.
+        """
+        # G=0.3 is well below the average limit (0.8+0.6)/2 = 0.7
+        # spill_amount = max(0.3 - 0.7, 0) = 0  →  output equals input
+        img = _to_np([[0.8, 0.3, 0.6]])
+        result = cu.despill(img, green_limit_mode="average", strength=1.0)
+        np.testing.assert_allclose(result, img, atol=1e-6)
+
 
 # ---------------------------------------------------------------------------
 # clean_matte

--- a/tests/test_e2e_workflow.py
+++ b/tests/test_e2e_workflow.py
@@ -1,0 +1,118 @@
+"""End-to-end workflow integration tests for CorridorKey.
+
+These tests exercise the full pipeline from ClipEntry asset discovery through
+run_inference output file creation.  The neural network engine is mocked so
+no model weights or GPU are required.
+
+Why integration-test run_inference?
+  Unit tests cover individual math functions.  This file verifies that the
+  orchestration layer (reading frames from disk, calling the engine, writing
+  output files to the right directories) works end-to-end on realistic
+  directory structures.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_result(h: int = 4, w: int = 4) -> dict:
+    """Return a minimal but valid process_frame result dict sized to (h, w)."""
+    return {
+        "alpha": np.full((h, w, 1), 0.8, dtype=np.float32),
+        "fg": np.full((h, w, 3), 0.6, dtype=np.float32),
+        "comp": np.full((h, w, 3), 0.5, dtype=np.float32),
+        "processed": np.full((h, w, 4), 0.4, dtype=np.float32),
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ClipEntry discovery → run_inference → files on disk
+# ---------------------------------------------------------------------------
+
+
+class TestE2EInferenceWorkflow:
+    """End-to-end: ClipEntry discovery → run_inference → output files on disk.
+
+    Uses the ``tmp_clip_dir`` fixture (shot_a: 2 frames, shot_b: 1 frame /
+    no alpha) and a mocked engine.  Verifies directory creation, frame I/O,
+    and file writing without a real engine or checkpoint.
+    """
+
+    def test_output_directories_created(self, tmp_clip_dir, monkeypatch):
+        """run_inference creates Output/{FG,Matte,Comp,Processed} for each clip."""
+        from clip_manager import ClipEntry, run_inference
+
+        entry = ClipEntry("shot_a", str(tmp_clip_dir / "shot_a"))
+        entry.find_assets()
+
+        # Supply blank answers to all interactive prompts inside run_inference
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        mock_engine = MagicMock()
+        mock_engine.process_frame.return_value = _fake_result()
+
+        with patch("CorridorKeyModule.backend.create_engine", return_value=mock_engine):
+            run_inference([entry], device="cpu")
+
+        out_root = tmp_clip_dir / "shot_a" / "Output"
+        assert (out_root / "FG").is_dir()
+        assert (out_root / "Matte").is_dir()
+        assert (out_root / "Comp").is_dir()
+        assert (out_root / "Processed").is_dir()
+
+    def test_output_files_written_per_frame(self, tmp_clip_dir, monkeypatch):
+        """run_inference writes exactly one output file per input frame.
+
+        shot_a has 2 input frames and 2 alpha frames, so each output
+        subdirectory should contain exactly 2 files after inference.
+        """
+        from clip_manager import ClipEntry, run_inference
+
+        entry = ClipEntry("shot_a", str(tmp_clip_dir / "shot_a"))
+        entry.find_assets()
+
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        mock_engine = MagicMock()
+        mock_engine.process_frame.return_value = _fake_result()
+
+        with patch("CorridorKeyModule.backend.create_engine", return_value=mock_engine):
+            run_inference([entry], device="cpu")
+
+        out_root = tmp_clip_dir / "shot_a" / "Output"
+        # shot_a has 2 frames → 2 files per output directory
+        assert len(list((out_root / "FG").glob("*.exr"))) == 2
+        assert len(list((out_root / "Matte").glob("*.exr"))) == 2
+        assert len(list((out_root / "Comp").glob("*.png"))) == 2
+        assert len(list((out_root / "Processed").glob("*.exr"))) == 2
+
+    def test_clip_without_alpha_skipped(self, tmp_clip_dir, monkeypatch):
+        """Clips missing an alpha asset are silently skipped by run_inference.
+
+        shot_b has Input but an empty AlphaHint, so it has no alpha_asset.
+        run_inference should process zero frames and create no Output directory.
+        """
+        from clip_manager import ClipEntry, run_inference
+
+        entry = ClipEntry("shot_b", str(tmp_clip_dir / "shot_b"))
+        entry.find_assets()
+        assert entry.alpha_asset is None  # precondition
+
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        mock_engine = MagicMock()
+        mock_engine.process_frame.return_value = _fake_result()
+
+        with patch("CorridorKeyModule.backend.create_engine", return_value=mock_engine):
+            run_inference([entry], device="cpu")
+
+        # No engine calls — clip was filtered out before inference
+        mock_engine.process_frame.assert_not_called()
+        assert not (tmp_clip_dir / "shot_b" / "Output").exists()

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -77,6 +77,22 @@ class TestProcessFrameOutputs:
         for key in ("alpha", "fg", "comp", "processed"):
             assert result[key].dtype == np.float32, f"{key} should be float32"
 
+    def test_alpha_output_range_is_zero_to_one(self, sample_frame_rgb, sample_mask, mock_greenformer):
+        """Alpha output must be in [0, 1] — values outside this range corrupt compositing."""
+        engine = _make_engine_with_mock(mock_greenformer)
+        result = engine.process_frame(sample_frame_rgb, sample_mask)
+        alpha = result["alpha"]
+        assert alpha.min() >= -0.01, f"alpha min {alpha.min():.4f} is below 0"
+        assert alpha.max() <= 1.01, f"alpha max {alpha.max():.4f} is above 1"
+
+    def test_fg_output_range_is_zero_to_one(self, sample_frame_rgb, sample_mask, mock_greenformer):
+        """FG output must be in [0, 1] — required for downstream sRGB conversion and EXR export."""
+        engine = _make_engine_with_mock(mock_greenformer)
+        result = engine.process_frame(sample_frame_rgb, sample_mask)
+        fg = result["fg"]
+        assert fg.min() >= -0.01, f"fg min {fg.min():.4f} is below 0"
+        assert fg.max() <= 1.01, f"fg max {fg.max():.4f} is above 1"
+
 
 # ---------------------------------------------------------------------------
 # Input color space handling
@@ -112,6 +128,15 @@ class TestProcessFrameColorSpace:
         # Should not crash — uint8 is auto-normalized to float32
         result = engine.process_frame(img_uint8, sample_mask)
         assert result["alpha"].dtype == np.float32
+
+    def test_model_called_exactly_once(self, sample_frame_rgb, sample_mask, mock_greenformer):
+        """The neural network model must be called exactly once per process_frame() call.
+
+        Double-inference would double latency and produce incorrect outputs.
+        """
+        engine = _make_engine_with_mock(mock_greenformer)
+        engine.process_frame(sample_frame_rgb, sample_mask)
+        assert mock_greenformer.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -169,3 +194,9 @@ class TestProcessFramePostProcessing:
 
         # Both should produce the same output
         np.testing.assert_allclose(result_2d["alpha"], result_3d["alpha"], atol=1e-5)
+
+    def test_refiner_scale_parameter_accepted(self, sample_frame_rgb, sample_mask, mock_greenformer):
+        """Non-default refiner_scale must not raise — the parameter must be threaded through."""
+        engine = _make_engine_with_mock(mock_greenformer)
+        result = engine.process_frame(sample_frame_rgb, sample_mask, refiner_scale=0.5)
+        assert result["alpha"].shape[:2] == sample_frame_rgb.shape[:2]


### PR DESCRIPTION
## What changed

- **`tests/test_color_utils.py`** — Added `test_green_below_limit_unchanged_numpy` to `TestDespill`: verifies the `max(..., 0)` clamp on `spill_amount` ensures no despill occurs (pixel returned unchanged) when G < (R+B)/2. Without that clamp, despill would incorrectly increase the green channel in non-spill regions.

- **`tests/test_inference_engine.py`** — Added 4 new tests across existing classes:
  - `test_alpha_output_range_is_zero_to_one` — alpha output must be in [0, 1]
  - `test_fg_output_range_is_zero_to_one` — FG output must be in [0, 1]
  - `test_model_called_exactly_once` — neural network called exactly once per `process_frame()` (guards against double-inference)
  - `test_refiner_scale_parameter_accepted` — `refiner_scale=0.5` must not raise

- **`tests/test_e2e_workflow.py`** — New file with 3 end-to-end integration tests that mock the engine and exercise the full orchestration path (asset discovery → frame I/O → output file creation):
  - `test_output_directories_created` — Output/FG, Matte, Comp, Processed dirs are created
  - `test_output_files_written_per_frame` — one output file per input frame in each dir
  - `test_clip_without_alpha_skipped` — clips missing alpha_asset are skipped before any engine calls

## Why it was needed

Test coverage gaps in the color math clamping guarantee, post-processing output bounds, and the end-to-end orchestration layer. The E2E tests in particular catch wiring bugs (wrong directory, missing file, double-inference) that unit tests of individual functions cannot see.

## How to verify

```bash
uv run pytest tests/test_color_utils.py tests/test_inference_engine.py tests/test_e2e_workflow.py -v
# Expected: 8 new tests pass, 0 failures, no GPU or model weights needed
uv run ruff check tests/test_color_utils.py tests/test_inference_engine.py tests/test_e2e_workflow.py
# Expected: All checks passed
```