### PR TITLE
docs: MLX weight conversion guide, EXR flags dedup, HANDOVER drift fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,33 @@ Auto mode prefers MLX on Apple Silicon when available.
    ```bash
    uv pip install corridorkey-mlx@git+https://github.com/nikopueringer/corridorkey-mlx.git
    ```
-2. Place converted weights in `CorridorKeyModule/checkpoints/`:
+2. Obtain the MLX weights (`.safetensors`) — pick **one** option:
+
+   **Option A — Download pre-converted weights (simplest):**
+   ```bash
+   # Download weights from GitHub Releases into a local cache directory
+   uv run python -m corridorkey_mlx weights download
+
+   # Print the cached path, then copy to the checkpoints folder
+   WEIGHTS=$(uv run python -m corridorkey_mlx weights download --print-path)
+   cp "$WEIGHTS" CorridorKeyModule/checkpoints/corridorkey_mlx.safetensors
+   ```
+
+   **Option B — Convert from an existing `.pth` checkpoint:**
+   ```bash
+   # Clone the MLX repo (contains the conversion script)
+   git clone https://github.com/nikopueringer/corridorkey-mlx.git
+   cd corridorkey-mlx
+   uv sync
+
+   # Convert (point --checkpoint at your CorridorKey.pth)
+   uv run python scripts/convert_weights.py \
+       --checkpoint ../CorridorKeyModule/checkpoints/CorridorKey_v1.0.pth \
+       --output ../CorridorKeyModule/checkpoints/corridorkey_mlx.safetensors
+   cd ..
+   ```
+
+   Either way the final file must be at:
    ```
    CorridorKeyModule/checkpoints/corridorkey_mlx.safetensors
    ```

--- a/clip_manager.py
+++ b/clip_manager.py
@@ -16,6 +16,7 @@ os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 import cv2
 import numpy as np
 
+from backend.frame_io import EXR_WRITE_FLAGS
 from device_utils import resolve_device
 
 if TYPE_CHECKING:
@@ -690,27 +691,18 @@ def run_inference(
             pred_fg = res["fg"]  # sRGB
             pred_alpha = res["alpha"]  # Linear
 
-            # 4. Save (EXR DWAB Half-Float)
-
-            # Compression Params
-            exr_flags = [
-                cv2.IMWRITE_EXR_TYPE,
-                cv2.IMWRITE_EXR_TYPE_HALF,
-                # DWAB fails. PXR24 verified as smallest working format (46KB vs ZIP 56KB vs B44A 688KB)
-                cv2.IMWRITE_EXR_COMPRESSION,
-                cv2.IMWRITE_EXR_COMPRESSION_PXR24,
-            ]
+            # 4. Save (EXR half-float, PXR24 compression — see backend/frame_io.py)
 
             # Save FG
             # pred_fg is RGB 0-1 float. Convert to BGR for OpenCV
             fg_bgr = cv2.cvtColor(pred_fg, cv2.COLOR_RGB2BGR)
-            cv2.imwrite(os.path.join(fg_dir, f"{input_stem}.exr"), fg_bgr, exr_flags)
+            cv2.imwrite(os.path.join(fg_dir, f"{input_stem}.exr"), fg_bgr, EXR_WRITE_FLAGS)
 
             # Save Matte
             if pred_alpha.ndim == 3:
                 pred_alpha = pred_alpha[:, :, 0]
             # Matte is single channel linear float
-            cv2.imwrite(os.path.join(matte_dir, f"{input_stem}.exr"), pred_alpha, exr_flags)
+            cv2.imwrite(os.path.join(matte_dir, f"{input_stem}.exr"), pred_alpha, EXR_WRITE_FLAGS)
 
             # 5. Generate Reference Comp
             comp_srgb = res["comp"]
@@ -724,7 +716,7 @@ def run_inference(
                 proc_rgba = res["processed"]
                 # Convert to BGRA for OpenCV
                 proc_bgra = cv2.cvtColor(proc_rgba, cv2.COLOR_RGBA2BGRA)
-                cv2.imwrite(os.path.join(proc_dir, f"{input_stem}.exr"), proc_bgra, exr_flags)
+                cv2.imwrite(os.path.join(proc_dir, f"{input_stem}.exr"), proc_bgra, EXR_WRITE_FLAGS)
 
             if on_frame_complete:
                 on_frame_complete(i, num_frames)

--- a/docs/LLM_HANDOVER.md
+++ b/docs/LLM_HANDOVER.md
@@ -44,14 +44,14 @@ The biggest challenge in this codebase revolves around **Color Space** and **Gam
 
 ## 3. The Inference Pipeline (`clip_manager.py`)
 
-Users generally run the system via local shell launcher scripts (`CorridorKey_local.bat` or `.sh`) which boot the `clip_manager.py` wizard. 
+Users generally run the system via local shell launcher scripts (`CorridorKey_DRAG_CLIPS_HERE_local.bat` or `CorridorKey_DRAG_CLIPS_HERE_local.sh`) which boot the `clip_manager.py` wizard.
 
 The pipeline works as follows:
 1.  **Scan:** Looks for folders (or dragged-and-dropped paths) containing an `Input` sequence (RGB) and an `AlphaHint` sequence (BW).
 2.  **Config:** Prompts the user for settings (Gamma space, Despill strength, Auto-Despeckle threshold, Refiner Strength).
 3.  **Execution:** Loops frame-by-frame, passing `[H, W, 3]` Numpy arrays to `engine.process_frame()`.
 4.  **Export:**
-    *   `FG` directory: Half-float EXR, RGB (Linear).
+    *   `FG` directory: Half-float EXR, RGB (**sRGB** — the model predicts straight FG in sRGB; convert to linear before compositing).
     *   `Matte` directory: Half-float EXR, Grayscale (Linear).
     *   `Processed` directory: Half-float EXR, RGBA (Linear, Premultiplied).
     *   `Comp` directory: 8-bit PNG (sRGB composite over a checkerboard, for quick preview).


### PR DESCRIPTION
## What changed

- **README.md** — MLX Setup step 2 now explains _how_ to obtain the `.safetensors` weights. Previously it only said "place converted weights in checkpoints/" with no path to get them. Added two concrete options: download via the `corridorkey_mlx` CLI (pre-converted from GitHub Releases) or convert from an existing `.pth` checkpoint using `scripts/convert_weights.py` from the `corridorkey-mlx` repo.

- **clip_manager.py** — Removed the inline `exr_flags = [...]` literal (4 lines, identical to the constant already defined in `backend/frame_io.py`). Now imports `EXR_WRITE_FLAGS` from `backend.frame_io` so the compression parameters are defined in exactly one place.

- **docs/LLM_HANDOVER.md** — Two drifted facts corrected:
  1. Launcher script names: `CorridorKey_local.bat/.sh` → `CorridorKey_DRAG_CLIPS_HERE_local.bat/.sh` (matching actual filenames on disk)
  2. FG EXR color space: was labeled "(Linear)" — FG is actually **sRGB** (the model predicts straight foreground in sRGB; callers must convert to linear before compositing, as the README already notes)

## Why it was needed

Apple Silicon users had no path to actually obtain or create the MLX weights from the README alone. The EXR flags duplication meant a future change to compression settings could be applied in one file but missed in the other. The HANDOVER doc drift would mislead AI assistants about launcher names and FG color space.

## How to verify

```bash
# No model or GPU required
uv run pytest                     # 195 passed, 1 skipped

# EXR_WRITE_FLAGS defined in exactly one place
grep -rn "IMWRITE_EXR_TYPE," backend/frame_io.py clip_manager.py
# → should appear only in frame_io.py (constant definition)

# clip_manager imports it
grep "EXR_WRITE_FLAGS" clip_manager.py
# → shows import + 3 usages, no literal list

uv run ruff check clip_manager.py backend/frame_io.py
# → All checks passed
```