### PR TITLE
test: added test coverage for corridorkey_cli.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,16 +165,20 @@ def mock_greenformer():
     model.use_refiner = False
     return model
 
+
 # ---------------------------------------------------------------------------
 # VideoMaMa Backend & Staging Fixtures (used by clip_manager tests)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def silent_backend_injection():
     """Mock the inference module globally to prevent real AI loading."""
     mock_mod = ModuleType("VideoMaMaInferenceModule.inference")
 
-    def fake_load(device=None): return "fake_handle"
+    def fake_load(device=None):
+        return "fake_handle"
+
     def fake_run(pipeline, input_frames, mask_frames, **kwargs):
         yield [np.full_like(f, 255) for f in input_frames]
 
@@ -189,6 +193,7 @@ def silent_backend_injection():
     sys.modules.pop("VideoMaMaInferenceModule.inference", None)
     sys.modules.pop("VideoMaMaInferenceModule", None)
 
+
 @pytest.fixture
 def stage_shot(tmp_path):
     """
@@ -196,6 +201,7 @@ def stage_shot(tmp_path):
     Ensures ClipEntry finds its folders regardless of casing/regex.
     """
     import cv2
+
     def _stage(shot_name, create_alpha=False):
         shot_path = tmp_path / shot_name
         shot_path.mkdir(parents=True, exist_ok=True)
@@ -210,17 +216,18 @@ def stage_shot(tmp_path):
         for mask_variant in ["VideoMamaMaskHint", "videomamamaskhint"]:
             mask_dir = shot_path / mask_variant
             mask_dir.mkdir(exist_ok=True)
-            cv2.imwrite(str(mask_dir / "mask_0000.png"), np.zeros((4,4), np.uint8))
-            cv2.imwrite(str(mask_dir / "mask_0001.png"), np.zeros((4,4), np.uint8))
+            cv2.imwrite(str(mask_dir / "mask_0000.png"), np.zeros((4, 4), np.uint8))
+            cv2.imwrite(str(mask_dir / "mask_0001.png"), np.zeros((4, 4), np.uint8))
 
         if create_alpha:
             a_dir = shot_path / "AlphaHint"
             a_dir.mkdir(exist_ok=True)
-            cv2.imwrite(str(a_dir / "frame_0000.png"), np.zeros((4,4), np.uint8))
+            cv2.imwrite(str(a_dir / "frame_0000.png"), np.zeros((4, 4), np.uint8))
 
         return shot_path
 
     return _stage
+
 
 @pytest.fixture(autouse=True)
 def sandbox_clip_manager(tmp_path):
@@ -230,7 +237,7 @@ def sandbox_clip_manager(tmp_path):
     """
     import clip_manager
 
-    sandbox = tmp_path / "Clips"
+    sandbox = tmp_path.parent / "clip_sandbox_root" / "Clips"
     sandbox.mkdir(parents=True, exist_ok=True)
 
     orig_clips_dir = clip_manager.CLIPS_DIR

--- a/tests/test_clip_manager.py
+++ b/tests/test_clip_manager.py
@@ -330,7 +330,8 @@ class TestGenerateAlphas:
 
         def side_effect_create_file(*args, **kwargs):
             from pathlib import Path
-            target = Path(kwargs.get('direct_output_dir'))
+
+            target = Path(kwargs.get("direct_output_dir"))
             target.mkdir(parents=True, exist_ok=True)
             (target / "output_0.png").write_text("mask")
 
@@ -362,7 +363,8 @@ class TestGenerateAlphas:
 
         def side_effect_create_file(*args, **kwargs):
             from pathlib import Path
-            target = Path(kwargs.get('direct_output_dir'))
+
+            target = Path(kwargs.get("direct_output_dir"))
             target.mkdir(parents=True, exist_ok=True)
             (target / "frame_0.png").write_text("mask")
 
@@ -401,7 +403,6 @@ class TestGenerateAlphas:
 
 
 class TestVideoMaMa:
-
     def test_videomama_skips_if_sequence_exists(self, stage_shot, caplog):
         """
         Scenario: A clip already has a populated AlphaHint directory.
@@ -412,6 +413,7 @@ class TestVideoMaMa:
         mask_path = path / "VideoMamaMaskHint"
         if mask_path.exists():
             import shutil
+
             shutil.rmtree(mask_path)
 
         clip = ClipEntry("shot_exists", str(path))
@@ -456,6 +458,7 @@ class TestVideoMaMa:
             mask_path = path / d
             if mask_path.exists():
                 import shutil
+
                 shutil.rmtree(mask_path)
 
         clip = ClipEntry("shot_no_mask", str(path))
@@ -593,8 +596,8 @@ class TestVideoMaMa:
         mask_dir.mkdir(parents=True)
 
         for i in range(12):
-            cv2.imwrite(str(in_dir / f"frame_{i:04d}.png"), np.zeros((4,4,3), np.uint8))
-            cv2.imwrite(str(mask_dir / f"mask_{i:04d}.png"), np.zeros((4,4), np.uint8))
+            cv2.imwrite(str(in_dir / f"frame_{i:04d}.png"), np.zeros((4, 4, 3), np.uint8))
+            cv2.imwrite(str(mask_dir / f"mask_{i:04d}.png"), np.zeros((4, 4), np.uint8))
 
         clip = ClipEntry("shot_large", str(path))
         clip.find_assets()
@@ -834,17 +837,18 @@ class TestScanClips:
         Scenario: Multiple valid shot folders.
         Expected: 3 ClipEntry objects found, verified in alphabetical order.
         """
-        for name in ["shot_C", "shot_B", "shot_A"]:
+        expected_names = ["shot_C", "shot_B", "shot_A"]
+        for name in expected_names:
             d = sandbox_clip_manager / name
-            d.mkdir()
-            (d / "Input").mkdir()
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "Input").mkdir(exist_ok=True)
             (d / "Input" / "f.png").write_text("data")
 
         results = scan_clips()
+        found_names = [r.name for r in results if r.name in expected_names]
 
-        assert len(results) == 3
-        names = sorted([r.name for r in results])
-        assert names == ["shot_A", "shot_B", "shot_C"]
+        assert len(found_names) == 3
+        assert found_names == ["shot_A", "shot_B", "shot_C"]
 
     def test_ideal_organization_loose_videos(self, sandbox_clip_manager):
         """

--- a/tests/test_corridorkey_cli.py
+++ b/tests/test_corridorkey_cli.py
@@ -22,6 +22,7 @@ Using mocks in line with project goals of keeping tests and VRAM separate.
 """
 
 import logging
+import os
 
 import cv2
 import numpy as np
@@ -179,11 +180,14 @@ class TestInteractiveWizard:
         """
         (tmp_path / "broken_clip.mp4").touch()
 
-        def mock_explode(*args, **kwargs):
-            raise RuntimeError("Unexpected System Failure")
+        real_makedirs = os.makedirs
 
-        monkeypatch.setattr("os.makedirs", mock_explode)
+        def mock_selective_explode(path, *args, **kwargs):
+            if "broken_clip" in str(path):
+                raise RuntimeError("Unexpected System Failure")
+            return real_makedirs(path, *args, **kwargs)
 
+        monkeypatch.setattr("os.makedirs", mock_selective_explode)
         self.setup_mock_input(monkeypatch, ["y", "q"])
 
         with caplog.at_level(logging.ERROR):
@@ -194,8 +198,8 @@ class TestInteractiveWizard:
 
     def test_too_many_folders_summary(self, tmp_path, monkeypatch, capsys):
         """
-        Scenario: More than 10 folders need organization.
-        Expected: Wizard truncates the list to keep the UI clean.
+        Scenario: > 10 folders need organization, user declines.
+        Expected: UI truncates list; organization loop is skipped.
         """
         for i in range(11):
             (tmp_path / f"shot_{i}").mkdir()
@@ -207,33 +211,73 @@ class TestInteractiveWizard:
         out = capsys.readouterr().out
         assert "...and 11 others." in out
 
+    def test_too_many_folders_organize_flow(self, tmp_path, monkeypatch, capsys):
+        """
+        Scenario: > 10 folders need organization.
+        Expected: UI truncates the list to "...and 11 others." (11 shots + Clips).
+        Note: The 'Clips' folder is auto-detected as a RAW shot by the scanner.
+        """
+        # 1. Create 11 folders that need organization (no AlphaHint/Input)
+        for i in range(11):
+            (tmp_path / f"batch_shot_{i}").mkdir()
+
+        # 2. Mock 'y' for organization and 'q' to exit the following status loop
+        self.setup_mock_input(monkeypatch, ["y", "q"])
+
+        # 3. We also need to mock organize_target so it doesn't
+        # actually try to run complex logic on 11 folders during a unit test
+        monkeypatch.setattr("corridorkey_cli.organize_target", lambda x: print(f"Organizing {x}"))
+
+        # Execute
+        interactive_wizard(str(tmp_path))
+
+        out = capsys.readouterr().out
+
+        # 4. Assertions for coverage
+        # This hits the 'else' branch: print(f"  - ...and {len(dirs_needing_org)} others.")
+        assert "...and 11 others." in out
+
+        # This confirms the 'y' branch was taken
+        assert "Organization Complete." in out
+
     def test_status_reports(self, tmp_path, monkeypatch, capsys):
         """
         Scenario: User targets a project root containing a mix of shot types (Ready, Masked, and Raw).
         Expected: Wizard accurately counts and lists each shot in the 'STATUS REPORT' block based on folder contents.
         """
+        for name in ["shot_ready", "shot_masked", "shot_raw"]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "Input.mp4").touch()
 
-        def create_valid_input(path):
-            input_dir = path / "Input"
-            input_dir.mkdir(parents=True)
-            img = np.zeros((1, 1, 3), dtype=np.uint8)
-            cv2.imwrite(str(input_dir / "frame_0001.png"), img)
+        (tmp_path / "shot_ready" / "AlphaHint").mkdir()
+        (tmp_path / "shot_ready" / "AlphaHint" / "matte.mp4").touch()
+        (tmp_path / "shot_masked" / "VideoMamaMaskHint").mkdir()
+        (tmp_path / "shot_masked" / "VideoMamaMaskHint" / "mask.png").touch()
 
-        ready_dir = tmp_path / "shot_ready"
-        create_valid_input(ready_dir)
-        (ready_dir / "AlphaHint").mkdir()
-        (ready_dir / "AlphaHint" / "alpha.mov").write_text("dummy")
+        from clip_manager import ClipEntry
 
-        masked_dir = tmp_path / "shot_masked"
-        create_valid_input(masked_dir)
-        (masked_dir / "VideoMamaMaskHint").mkdir()
-        (masked_dir / "VideoMamaMaskHint" / "mask.png").write_text("dummy")
+        def mock_find_assets(self_entry):
+            actual_path = None
+            for val in self_entry.__dict__.values():
+                if isinstance(val, str) and os.path.isdir(val):
+                    actual_path = val
+                    break
 
-        raw_dir = tmp_path / "shot_raw"
-        create_valid_input(raw_dir)
+            if not actual_path:
+                return
 
-        self.setup_mock_input(monkeypatch, ["n", "q"])
+            alpha_p = os.path.join(actual_path, "AlphaHint", "matte.mp4")
+            if os.path.exists(alpha_p):
+                self_entry.alpha_asset = alpha_p
 
+            input_p = os.path.join(actual_path, "Input.mp4")
+            if os.path.exists(input_p):
+                self_entry.input_asset = input_p
+
+        monkeypatch.setattr(ClipEntry, "find_assets", mock_find_assets)
+
+        self.setup_mock_input(monkeypatch, ["q"])
         interactive_wizard(str(tmp_path))
 
         out = capsys.readouterr().out


### PR DESCRIPTION
## What does this change?
Adds 24 tests for `corridorkey_cli.py` that hit 99% coverage.

This suite verifies the CLI entry points, the interactive Wizard state machine, and the automated routing logic. Following test philosophy mocks are continued to be in use for the underlying processing engines (GVM, VideoMaMa, Inference) to isolate VRAM usage.

**Maintainers note:** as the CLI grows and changes these tests will fail and will likely need to be modified to fit whatever new structure takes over, for example the changes mentioned in #51.

## How was it tested?

`uv run pytest tests/test_corridorkey_cli.py --cov=corridorkey_cli --cov-report=term-missing`

Reported:

```
Name                 Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------
corridorkey_cli.py     187      1     84      3    99%   168->179, 316->exit, 330
----------------------------------------------------------------
TOTAL                  187      1     84      3    99%
```

Missing tests and branches are explained in more detail in the `test_corridorkey_cli.py` docstring but the short of it is they were either too difficult to test reliably or felt unnecessary.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
