### PR TITLE
docs: add DeepWiki codebase documentation link (closes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ MLX uses img_size=2048 by default (same as Torch).
 
 For developers looking for more details on the specifics of what is happening in the CorridorKey engine, check out the README in the `/CorridorKeyModule` folder. We also have a dedicated handover document outlining the pipeline architecture for AI assistants in `/docs/LLM_HANDOVER.md`.
 
+You can also explore the full, auto-generated codebase documentation on [DeepWiki](https://deepwiki.com/nikopueringer/CorridorKey).
+
 ### Running Tests
 
 The project includes unit tests for the color math and compositing pipeline. No GPU or model weights required — tests run in a few seconds on any machine.


### PR DESCRIPTION
## What changed
Added a one-line DeepWiki link in the **Advanced Usage** section of `README.md`.

## Why it was needed
Issue #85 — DeepWiki auto-generates and hosts interactive codebase documentation (call graph, module summaries, dependency graph) from the GitHub repo. Linking it from the README gives contributors an always-up-to-date reference without any maintenance overhead.

## How to verify
```bash
# Confirm the link appears in README under Advanced Usage
grep -n "DeepWiki" README.md
# Then visit: https://deepwiki.com/nikopueringer/CorridorKey
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>