### PR TITLE
fix: guard against opencv-python-headless transitive conflict (closes #17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,16 @@ omit = [
     "test_vram.py",               # manual GPU smoke test, not part of the pytest suite
 ]
 
+[tool.uv]
+# Guard against transitive deps (diffusers, imageio, PIMS) silently pulling in
+# opencv-python-headless, which conflicts with opencv-python at the file level
+# (both install into the same cv2/ directory). If any future dep requests
+# opencv-python-headless, uv resolution will fail explicitly rather than
+# corrupting the environment.
+constraint-dependencies = [
+    "opencv-python-headless==99999",
+]
+
 [[tool.uv.index]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl/cu128" # CUDA 12.6 doesn't support RTX 5000 Series

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 
+[manifest]
+constraints = [{ name = "opencv-python-headless", specifier = "==99999" }]
+
 [[package]]
 name = "accelerate"
 version = "1.12.0"


### PR DESCRIPTION
## What changed
Added `constraint-dependencies = ["opencv-python-headless==99999"]` to the `[tool.uv]` section of `pyproject.toml`, plus the corresponding `[manifest]` metadata in `uv.lock`.

## Why it was needed
Issue #17 — `opencv-python` and `opencv-python-headless` both install into the same `cv2/` directory and corrupt each other silently. Transitive deps (`diffusers`, `imageio`, `PIMS`) can pull in the headless variant without warning.

## Approach vs PR #62
PR #62 uses `override-dependencies` with the `extra == 'never'` marker trick — a semantically opaque mechanism that silently removes the package from resolution.

This PR uses `constraint-dependencies = ["opencv-python-headless==99999"]`, which is the mechanism uv documents for blocking packages:
- If any transitive dep requests `opencv-python-headless`, uv's resolver must also satisfy `==99999`. Since version 99999 doesn't exist on PyPI, resolution **fails loudly** with an explicit conflict message.
- Intent is immediately clear to future maintainers from the accompanying comment.
- `constraint-dependencies` (unlike `override-dependencies`) doesn't override legitimate direct-dep requests — it only constrains transitive resolution.

## uv.lock impact
The lock diff is exactly 3 lines — a `[manifest]` entry recording the new constraint. Zero package resolutions changed, so this is safe to commit from any platform.

## How to verify
```bash
# Constraint is present in pyproject.toml
grep "opencv-python-headless" pyproject.toml

# Lock file records the constraint (no package changes)
grep -A2 "\[manifest\]" uv.lock

# Existing tests still pass
uv run pytest
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>