### PR TITLE
fix: apply piecewise sRGB gamma correction for EXR sequences (#116)

### DIFF
--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -17,6 +17,8 @@ from typing import Callable
 import cv2
 import numpy as np
 
+from CorridorKeyModule.core.color_utils import linear_to_srgb
+
 from .validators import normalize_mask_channels, normalize_mask_dtype
 
 logger = logging.getLogger(__name__)
@@ -35,8 +37,8 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> np.ndarray 
 
     Args:
         fpath: Absolute path to image file.
-        gamma_correct_exr: If True, apply gamma 1/2.2 to EXR data
-            (converts linear → approximate sRGB for models expecting sRGB).
+        gamma_correct_exr: If True, apply piecewise sRGB transfer function
+            to EXR data (converts linear → sRGB for models expecting sRGB).
 
     Returns:
         float32 array [H, W, 3] in RGB order, or None if read fails.
@@ -54,7 +56,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> np.ndarray 
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         result = np.maximum(img_rgb, 0.0).astype(np.float32)
         if gamma_correct_exr:
-            result = np.power(result, 1.0 / 2.2).astype(np.float32)
+            result = linear_to_srgb(result).astype(np.float32)
         return result
     else:
         img = cv2.imread(fpath)

--- a/clip_manager.py
+++ b/clip_manager.py
@@ -16,7 +16,7 @@ os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 import cv2
 import numpy as np
 
-from backend.frame_io import EXR_WRITE_FLAGS
+from backend.frame_io import EXR_WRITE_FLAGS, read_image_frame
 from device_utils import resolve_device
 
 if TYPE_CHECKING:
@@ -628,12 +628,9 @@ def run_inference(
 
                 is_exr = fpath.lower().endswith(".exr")
                 if is_exr:
-                    img_linear = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
-                    if img_linear is None:
+                    img_srgb = read_image_frame(fpath, gamma_correct_exr=not input_is_linear)
+                    if img_srgb is None:
                         continue
-                    img_linear_rgb = cv2.cvtColor(img_linear, cv2.COLOR_BGR2RGB)
-                    # Support overriding EXR behavior if user picked 's'
-                    img_srgb = np.maximum(img_linear_rgb, 0.0)
                 else:
                     img_bgr = cv2.imread(fpath)
                     if img_bgr is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest", "pytest-cov", "ruff"]
+dev = ["pytest", "pytest-cov", "ruff", "hypothesis"]
 docs = ["zensical>=0.0.24"]
 
 [project.scripts]

--- a/tests/test_exr_gamma_bug_condition.py
+++ b/tests/test_exr_gamma_bug_condition.py
@@ -1,0 +1,266 @@
+"""Bug condition exploration tests for EXR gamma correction.
+
+These tests encode the EXPECTED (correct) behavior for EXR+sRGB gamma handling.
+On UNFIXED code they are expected to FAIL, confirming the bug exists.
+
+**Validates: Requirements 1.1, 1.2, 1.3**
+
+Defect 1 (1.1): run_inference EXR path ignores input_is_linear=False — no gamma correction applied.
+Defect 2 (1.2): process_frame receives raw linear data with input_is_linear=False semantics.
+Defect 3 (1.3): read_image_frame uses naive pow(1/2.2) instead of piecewise sRGB transfer function.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
+
+from backend.frame_io import read_image_frame
+from CorridorKeyModule.core.color_utils import linear_to_srgb
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Float32 pixel values in [0, 1] — the valid linear range for EXR data
+linear_pixel_values = st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+
+# Small float32 RGB arrays representing EXR frame data
+# Using small sizes (4x4 to 16x16) to keep tests fast
+linear_pixel_arrays = arrays(
+    dtype=np.float32,
+    shape=st.tuples(
+        st.integers(min_value=4, max_value=16),
+        st.integers(min_value=4, max_value=16),
+        st.just(3),
+    ),
+    elements=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+
+# Strategy that specifically targets the sRGB piecewise threshold region
+# Values near 0.0031308 where naive pow(1/2.2) diverges from piecewise sRGB
+threshold_pixel_values = st.one_of(
+    # Values below the threshold (linear segment of sRGB)
+    st.floats(min_value=0.0, max_value=0.0031308, allow_nan=False, allow_infinity=False),
+    # Values right around the threshold
+    st.floats(min_value=0.002, max_value=0.005, allow_nan=False, allow_infinity=False),
+    # Values above the threshold (power segment of sRGB)
+    st.floats(min_value=0.0031308, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_exr(path: str, rgb_data: np.ndarray) -> None:
+    """Write a float32 RGB array as a BGR EXR file via OpenCV."""
+    bgr = cv2.cvtColor(rgb_data.astype(np.float32), cv2.COLOR_RGB2BGR)
+    cv2.imwrite(path, bgr)
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: naive pow(1/2.2) vs piecewise sRGB in read_image_frame
+# ---------------------------------------------------------------------------
+
+
+class TestDefect3NaivePowVsPiecewiseSRGB:
+    """**Validates: Requirements 1.3**
+
+    read_image_frame(exr_path, gamma_correct_exr=True) should produce output
+    matching linear_to_srgb() from color_utils.py, NOT np.power(data, 1/2.2).
+    """
+
+    @given(data=linear_pixel_arrays)
+    @settings(max_examples=50, deadline=None)
+    def test_gamma_corrected_exr_matches_piecewise_srgb(self, data: np.ndarray) -> None:
+        """When gamma_correct_exr=True, the result must match the piecewise
+        sRGB transfer function, not the naive pow(1/2.2) approximation.
+
+        **Validates: Requirements 1.3**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exr_path = os.path.join(tmpdir, "test.exr")
+            _write_exr(exr_path, data)
+
+            result = read_image_frame(exr_path, gamma_correct_exr=True)
+            assert result is not None, "read_image_frame returned None"
+
+            # The expected output: piecewise sRGB transfer function
+            raw = cv2.imread(exr_path, cv2.IMREAD_UNCHANGED)
+            if raw.ndim == 3 and raw.shape[2] == 4:
+                raw = raw[:, :, :3]
+            raw_rgb = cv2.cvtColor(raw, cv2.COLOR_BGR2RGB)
+            linear_clamped = np.maximum(raw_rgb, 0.0).astype(np.float32)
+            expected = linear_to_srgb(linear_clamped)
+
+            np.testing.assert_allclose(
+                result,
+                expected,
+                atol=1e-6,
+                err_msg=(
+                    "read_image_frame with gamma_correct_exr=True does not match "
+                    "linear_to_srgb(). It likely uses naive pow(1/2.2) instead of "
+                    "the piecewise sRGB transfer function."
+                ),
+            )
+
+    @given(
+        pixel_val=threshold_pixel_values,
+    )
+    @settings(max_examples=100, deadline=None)
+    def test_threshold_region_divergence(self, pixel_val: float) -> None:
+        """Specifically test values near the 0.0031308 threshold where
+        naive pow(1/2.2) and piecewise sRGB diverge most.
+
+        **Validates: Requirements 1.3**
+        """
+        # Create a small 2x2 image with the test pixel value
+        data = np.full((2, 2, 3), pixel_val, dtype=np.float32)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exr_path = os.path.join(tmpdir, "threshold_test.exr")
+            _write_exr(exr_path, data)
+
+            result = read_image_frame(exr_path, gamma_correct_exr=True)
+            assert result is not None
+
+            expected = linear_to_srgb(data)
+
+            np.testing.assert_allclose(
+                result,
+                expected,
+                atol=1e-6,
+                err_msg=(
+                    f"At pixel value {pixel_val} (near sRGB threshold 0.0031308), "
+                    f"read_image_frame produces {result.flat[0]:.8f} but piecewise "
+                    f"sRGB expects {expected.flat[0]:.8f}. "
+                    f"Naive pow(1/2.2) would give {np.power(pixel_val, 1.0 / 2.2):.8f}."
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 & 2: run_inference EXR path ignores gamma + wrong semantics
+# ---------------------------------------------------------------------------
+
+
+class TestDefect1And2RunInferenceEXRPath:
+    """**Validates: Requirements 1.1, 1.2**
+
+    When input is an EXR image sequence with input_is_linear=False,
+    the frame passed to process_frame() must have sRGB gamma applied
+    and process_frame must receive input_is_linear=False with properly
+    gamma-corrected data.
+    """
+
+    @given(data=linear_pixel_arrays)
+    @settings(max_examples=30, deadline=None)
+    def test_exr_srgb_frame_is_gamma_corrected(self, data: np.ndarray) -> None:
+        """Given an EXR image sequence with input_is_linear=False, the frame
+        passed to process_frame() must NOT be raw linear data — it must have
+        sRGB gamma applied.
+
+        **Validates: Requirements 1.1, 1.2**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up a minimal clip structure with one EXR frame
+            input_dir = os.path.join(tmpdir, "Input")
+            alpha_dir = os.path.join(tmpdir, "AlphaHint")
+            os.makedirs(input_dir)
+            os.makedirs(alpha_dir)
+
+            h, w = data.shape[:2]
+
+            # Write EXR input frame
+            exr_path = os.path.join(input_dir, "frame_00000.exr")
+            _write_exr(exr_path, data)
+
+            # Write a matching alpha mask (simple grayscale PNG)
+            mask = np.full((h, w), 128, dtype=np.uint8)
+            cv2.imwrite(os.path.join(alpha_dir, "frame_00000.png"), mask)
+
+            # What we expect: the linear data should be gamma-corrected
+            # via piecewise sRGB before reaching process_frame
+            expected_srgb = linear_to_srgb(np.maximum(data, 0.0).astype(np.float32))
+
+            # We'll capture what process_frame actually receives by patching it
+            captured_args = {}
+
+            def mock_process_frame(image, mask_linear, *, input_is_linear=False, **kwargs):
+                captured_args["image"] = image.copy()
+                captured_args["input_is_linear"] = input_is_linear
+                # Return minimal valid result
+                h_img, w_img = image.shape[:2]
+                return {
+                    "alpha": np.zeros((h_img, w_img, 1), dtype=np.float32),
+                    "fg": np.zeros((h_img, w_img, 3), dtype=np.float32),
+                    "comp": np.zeros((h_img, w_img, 3), dtype=np.float32),
+                    "processed": np.zeros((h_img, w_img, 4), dtype=np.float32),
+                }
+
+            # Build a mock clip that looks like an EXR image sequence
+            mock_clip = MagicMock()
+            mock_clip.name = "test_clip"
+            mock_clip.root_path = tmpdir
+            mock_clip.input_asset.type = "sequence"
+            mock_clip.input_asset.path = input_dir
+            mock_clip.input_asset.frame_count = 1
+            mock_clip.alpha_asset.type = "sequence"
+            mock_clip.alpha_asset.path = alpha_dir
+            mock_clip.alpha_asset.frame_count = 1
+
+            # Create mock settings with input_is_linear=False (sRGB selected)
+            mock_settings = MagicMock()
+            mock_settings.input_is_linear = False
+            mock_settings.despill_strength = 1.0
+            mock_settings.auto_despeckle = False
+            mock_settings.despeckle_size = 400
+            mock_settings.refiner_scale = 1.0
+
+            # Mock the engine
+            mock_engine = MagicMock()
+            mock_engine.process_frame = mock_process_frame
+
+            # Patch create_engine where it's imported from inside run_inference
+            with patch("CorridorKeyModule.backend.create_engine", return_value=mock_engine):
+                from clip_manager import run_inference
+
+                run_inference(
+                    [mock_clip],
+                    device="cpu",
+                    max_frames=1,
+                    settings=mock_settings,
+                )
+
+            assert "image" in captured_args, "process_frame was never called — clip setup may be wrong"
+
+            actual_image = captured_args["image"]
+            actual_is_linear = captured_args["input_is_linear"]
+
+            # Defect 1: The frame should be gamma-corrected (sRGB), not raw linear
+            # On buggy code, img_srgb contains raw linear data
+            np.testing.assert_allclose(
+                actual_image,
+                expected_srgb,
+                atol=1e-5,
+                err_msg=(
+                    "Frame passed to process_frame() is raw linear data, not "
+                    "sRGB gamma-corrected. The EXR branch in run_inference() "
+                    "does not apply gamma correction when input_is_linear=False."
+                ),
+            )
+
+            # Defect 2: input_is_linear should be False (sRGB semantics)
+            assert actual_is_linear is False, (
+                f"process_frame received input_is_linear={actual_is_linear}, "
+                f"expected False. The EXR data has wrong semantics."
+            )

--- a/tests/test_exr_gamma_preservation.py
+++ b/tests/test_exr_gamma_preservation.py
@@ -1,0 +1,313 @@
+"""Preservation property tests for EXR gamma correction bugfix.
+
+These tests verify that non-buggy code paths remain unchanged after the fix.
+They MUST PASS on the current UNFIXED code — they establish the baseline
+behavior that must be preserved.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+3.1: Linear EXR path (input_is_linear=True) passes data through unchanged.
+3.2: Standard image path (PNG/JPG/TIFF) reads uint8 normalized to [0,1] float32.
+3.3: Video path continues to decode frames as sRGB regardless of input_is_linear.
+3.4: read_image_frame() with gamma_correct_exr=False returns raw linear EXR data.
+3.5: Linear EXR inputs with input_is_linear=True produce byte-exact identical output.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
+
+from backend.frame_io import read_image_frame
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Float32 pixel arrays in [0, 1] for EXR data
+linear_pixel_arrays = arrays(
+    dtype=np.float32,
+    shape=st.tuples(
+        st.integers(min_value=4, max_value=16),
+        st.integers(min_value=4, max_value=16),
+        st.just(3),
+    ),
+    elements=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+
+# uint8 pixel arrays for standard image data (PNG/JPG)
+uint8_pixel_arrays = arrays(
+    dtype=np.uint8,
+    shape=st.tuples(
+        st.integers(min_value=4, max_value=16),
+        st.integers(min_value=4, max_value=16),
+        st.just(3),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_exr(path: str, rgb_data: np.ndarray) -> None:
+    """Write a float32 RGB array as a BGR EXR file via OpenCV."""
+    bgr = cv2.cvtColor(rgb_data.astype(np.float32), cv2.COLOR_RGB2BGR)
+    cv2.imwrite(path, bgr)
+
+
+def _write_png(path: str, rgb_data: np.ndarray) -> None:
+    """Write a uint8 RGB array as a BGR PNG file via OpenCV."""
+    bgr = cv2.cvtColor(rgb_data, cv2.COLOR_RGB2BGR)
+    cv2.imwrite(path, bgr)
+
+
+# ---------------------------------------------------------------------------
+# 3.4: gamma_correct_exr=False returns raw linear EXR data (no transformation)
+# ---------------------------------------------------------------------------
+
+
+class TestPreservationLinearEXRRead:
+    """**Validates: Requirements 3.1, 3.4**
+
+    read_image_frame() with gamma_correct_exr=False (the default) returns
+    raw linear EXR data with no gamma transformation applied. The result
+    must be identical to what cv2.imread produces (clamped to >= 0, as float32).
+    """
+
+    @given(data=linear_pixel_arrays)
+    @settings(max_examples=50, deadline=None)
+    def test_exr_default_returns_raw_linear_data(self, data: np.ndarray) -> None:
+        """For all float32 arrays in [0, 1], read_image_frame with default
+        params (gamma_correct_exr=False) returns data identical to raw
+        cv2.imread output — no transformation applied.
+
+        **Validates: Requirements 3.4**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exr_path = os.path.join(tmpdir, "test.exr")
+            _write_exr(exr_path, data)
+
+            result = read_image_frame(exr_path)
+            assert result is not None, "read_image_frame returned None"
+
+            # Reconstruct what raw cv2.imread would produce
+            raw = cv2.imread(exr_path, cv2.IMREAD_UNCHANGED)
+            if raw.ndim == 3 and raw.shape[2] == 4:
+                raw = raw[:, :, :3]
+            raw_rgb = cv2.cvtColor(raw, cv2.COLOR_BGR2RGB)
+            expected = np.maximum(raw_rgb, 0.0).astype(np.float32)
+
+            np.testing.assert_array_equal(
+                result,
+                expected,
+                err_msg=(
+                    "read_image_frame with gamma_correct_exr=False (default) "
+                    "should return raw linear EXR data identical to cv2.imread "
+                    "output. No transformation should be applied."
+                ),
+            )
+
+    @given(data=linear_pixel_arrays)
+    @settings(max_examples=50, deadline=None)
+    def test_exr_explicit_false_returns_raw_linear_data(self, data: np.ndarray) -> None:
+        """Explicitly passing gamma_correct_exr=False produces the same
+        result as the default — raw linear data, no transformation.
+
+        **Validates: Requirements 3.1, 3.4**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exr_path = os.path.join(tmpdir, "test.exr")
+            _write_exr(exr_path, data)
+
+            result_default = read_image_frame(exr_path)
+            result_explicit = read_image_frame(exr_path, gamma_correct_exr=False)
+
+            assert result_default is not None
+            assert result_explicit is not None
+
+            np.testing.assert_array_equal(
+                result_default,
+                result_explicit,
+                err_msg=(
+                    "read_image_frame(path) and read_image_frame(path, "
+                    "gamma_correct_exr=False) should produce identical results."
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3.2: Standard image path reads uint8 normalized to [0,1] float32
+# ---------------------------------------------------------------------------
+
+
+class TestPreservationStandardImageRead:
+    """**Validates: Requirements 3.2**
+
+    For PNG/JPG/TIFF with input_is_linear=False, data is read as uint8,
+    divided by 255, and the result is float32 in [0, 1].
+    """
+
+    @given(data=uint8_pixel_arrays)
+    @settings(max_examples=50, deadline=None)
+    def test_png_read_returns_uint8_normalized(self, data: np.ndarray) -> None:
+        """For all uint8 arrays, standard image read returns
+        array.astype(float32) / 255.0.
+
+        **Validates: Requirements 3.2**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            png_path = os.path.join(tmpdir, "test.png")
+            _write_png(png_path, data)
+
+            result = read_image_frame(png_path)
+            assert result is not None, "read_image_frame returned None for PNG"
+
+            # Reconstruct expected: read as uint8 BGR, convert to RGB, / 255
+            raw = cv2.imread(png_path)
+            raw_rgb = cv2.cvtColor(raw, cv2.COLOR_BGR2RGB)
+            expected = raw_rgb.astype(np.float32) / 255.0
+
+            np.testing.assert_array_equal(
+                result,
+                expected,
+                err_msg=(
+                    "Standard image read should return uint8 data normalized to [0,1] float32 via division by 255."
+                ),
+            )
+
+    @given(data=uint8_pixel_arrays)
+    @settings(max_examples=50, deadline=None)
+    def test_png_result_dtype_and_range(self, data: np.ndarray) -> None:
+        """Standard image read always returns float32 in [0, 1].
+
+        **Validates: Requirements 3.2**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            png_path = os.path.join(tmpdir, "test.png")
+            _write_png(png_path, data)
+
+            result = read_image_frame(png_path)
+            assert result is not None
+
+            assert result.dtype == np.float32, f"Expected float32 dtype, got {result.dtype}"
+            assert result.min() >= 0.0, "Result contains negative values"
+            assert result.max() <= 1.0, "Result contains values > 1.0"
+
+
+# ---------------------------------------------------------------------------
+# 3.1, 3.5: Linear EXR with input_is_linear=True in run_inference
+# ---------------------------------------------------------------------------
+
+
+class TestPreservationLinearEXRInference:
+    """**Validates: Requirements 3.1, 3.5**
+
+    When input is an EXR image sequence with input_is_linear=True,
+    the data passes through without gamma correction and process_frame()
+    receives input_is_linear=True with raw linear data.
+    """
+
+    @given(data=linear_pixel_arrays)
+    @settings(max_examples=30, deadline=None)
+    def test_linear_exr_passes_through_unchanged(self, data: np.ndarray) -> None:
+        """For all linear EXR inputs with input_is_linear=True, the data
+        reaching process_frame() is byte-exact identical to the raw EXR
+        read — no gamma correction applied.
+
+        **Validates: Requirements 3.1, 3.5**
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = os.path.join(tmpdir, "Input")
+            alpha_dir = os.path.join(tmpdir, "AlphaHint")
+            os.makedirs(input_dir)
+            os.makedirs(alpha_dir)
+
+            h, w = data.shape[:2]
+
+            # Write EXR input frame
+            exr_path = os.path.join(input_dir, "frame_00000.exr")
+            _write_exr(exr_path, data)
+
+            # Write a matching alpha mask
+            mask = np.full((h, w), 128, dtype=np.uint8)
+            cv2.imwrite(os.path.join(alpha_dir, "frame_00000.png"), mask)
+
+            # Read what the raw EXR data looks like after cv2 round-trip
+            raw = cv2.imread(exr_path, cv2.IMREAD_UNCHANGED)
+            if raw.ndim == 3 and raw.shape[2] == 4:
+                raw = raw[:, :, :3]
+            raw_rgb = cv2.cvtColor(raw, cv2.COLOR_BGR2RGB)
+            expected_linear = np.maximum(raw_rgb, 0.0).astype(np.float32)
+
+            # Capture what process_frame actually receives
+            captured_args = {}
+
+            def mock_process_frame(image, mask_linear, *, input_is_linear=False, **kwargs):
+                captured_args["image"] = image.copy()
+                captured_args["input_is_linear"] = input_is_linear
+                h_img, w_img = image.shape[:2]
+                return {
+                    "alpha": np.zeros((h_img, w_img, 1), dtype=np.float32),
+                    "fg": np.zeros((h_img, w_img, 3), dtype=np.float32),
+                    "comp": np.zeros((h_img, w_img, 3), dtype=np.float32),
+                    "processed": np.zeros((h_img, w_img, 4), dtype=np.float32),
+                }
+
+            mock_clip = MagicMock()
+            mock_clip.name = "test_clip"
+            mock_clip.root_path = tmpdir
+            mock_clip.input_asset.type = "sequence"
+            mock_clip.input_asset.path = input_dir
+            mock_clip.input_asset.frame_count = 1
+            mock_clip.alpha_asset.type = "sequence"
+            mock_clip.alpha_asset.path = alpha_dir
+            mock_clip.alpha_asset.frame_count = 1
+
+            # input_is_linear=True — user confirmed linear EXR
+            mock_settings = MagicMock()
+            mock_settings.input_is_linear = True
+            mock_settings.despill_strength = 1.0
+            mock_settings.auto_despeckle = False
+            mock_settings.despeckle_size = 400
+            mock_settings.refiner_scale = 1.0
+
+            mock_engine = MagicMock()
+            mock_engine.process_frame = mock_process_frame
+
+            with patch("CorridorKeyModule.backend.create_engine", return_value=mock_engine):
+                from clip_manager import run_inference
+
+                run_inference(
+                    [mock_clip],
+                    device="cpu",
+                    max_frames=1,
+                    settings=mock_settings,
+                )
+
+            assert "image" in captured_args, "process_frame was never called"
+
+            # The frame should be raw linear data — no gamma correction
+            np.testing.assert_allclose(
+                captured_args["image"],
+                expected_linear,
+                atol=1e-6,
+                err_msg=(
+                    "With input_is_linear=True, the EXR data reaching "
+                    "process_frame() should be raw linear — identical to "
+                    "cv2.imread output. No gamma correction should be applied."
+                ),
+            )
+
+            # input_is_linear should be True
+            assert captured_args["input_is_linear"] is True, (
+                f"process_frame received input_is_linear={captured_args['input_is_linear']}, expected True"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,14 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -210,7 +213,8 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -282,9 +286,11 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
@@ -369,9 +375,9 @@ dependencies = [
     { name = "timm" },
     { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.22.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.22.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.22.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.22.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchvision", version = "0.22.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "triton-windows", marker = "sys_platform == 'win32'" },
@@ -380,6 +386,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -418,6 +425,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -719,6 +727,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872, upload-time = "2026-02-26T15:35:32.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/74/2bc951622e2dbba1af9a460d93c51d15e458becd486e62c29cc0ccb08178/huggingface_hub-1.5.0-py3-none-any.whl", hash = "sha256:c9c0b3ab95a777fc91666111f3b3ede71c0cdced3614c553a64e98920585c4ee", size = 596261, upload-time = "2026-02-26T15:35:31.1Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
 ]
 
 [[package]]
@@ -1027,7 +1048,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -1041,9 +1063,11 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
@@ -1058,7 +1082,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -1125,9 +1150,11 @@ name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
@@ -1808,6 +1835,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1824,7 +1860,8 @@ name = "tifffile"
 version = "2025.5.10"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
@@ -1841,9 +1878,11 @@ name = "tifffile"
 version = "2026.2.24"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
@@ -1866,9 +1905,9 @@ dependencies = [
     { name = "safetensors" },
     { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.22.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.22.1", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "torchvision", version = "0.22.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.22.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchvision", version = "0.22.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 
 [[package]]
@@ -1969,10 +2008,13 @@ name = "torch"
 version = "2.7.1+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
@@ -2024,15 +2066,18 @@ name = "torchvision"
 version = "0.22.1"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
+    "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cu128/torchvision-0.22.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3a41b87628c0d6095839c43a1dd706670e7e5a56edc5860e700e1ba22c3ef8af" },
@@ -2070,15 +2115,15 @@ name = "torchvision"
 version = "0.22.1+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.11' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cu128/torchvision-0.22.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:538f4db667286d939b4eee0a66d31ed21b51186668006b0e0ffe20338ecc7e00" },


### PR DESCRIPTION
## What does this change?

Fixes #116 — EXR image sequences with `input_is_linear=False` (sRGB gamma selected) were silently treated as linear, producing incorrect output colors.

Two root causes addressed:

1. **`clip_manager.py` / `run_inference()`**: The EXR branch read frames with raw `cv2.imread` and never applied gamma correction, even when the user selected sRGB. Now calls `read_image_frame(fpath, gamma_correct_exr=not input_is_linear)` so EXR data gets proper sRGB gamma when needed, and passes through unchanged when `input_is_linear=True`.

2. **`backend/frame_io.py` / `read_image_frame()`**: The `gamma_correct_exr=True` path used a naive `pow(1/2.2)` approximation. Now uses the piecewise sRGB transfer function (`linear_to_srgb` from `color_utils.py`, IEC 61966-2-1), which is accurate especially in dark tones below the 0.0031308 threshold.

## How was it tested?

Property-based tests using Hypothesis covering all three defects:

- **Bug condition tests** (`tests/test_exr_gamma_bug_condition.py`): Verified on unfixed code that all 3 tests fail (confirming the bug), then pass after the fix. Includes threshold-region testing near 0.0031308 where naive pow diverges from piecewise sRGB.
- **Preservation tests** (`tests/test_exr_gamma_preservation.py`): Verified that linear EXR reads (`gamma_correct_exr=False`), standard image reads (PNG uint8→float32), and the `input_is_linear=True` inference path all remain byte-exact identical before and after the fix.
- Full `pytest -x -v` suite passes (185 tests). `ruff check` and `ruff format --check` clean.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
