### PR TITLE
fallback to eager mode on compilation failure

### DIFF
--- a/CorridorKeyModule/core/model_transformer.py
+++ b/CorridorKeyModule/core/model_transformer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 
 import timm
 import torch
@@ -143,8 +142,6 @@ class CNNRefinerModule(nn.Module):
         return self.final(x) * 10.0
 
 
-# We only tested compilation on windows and linux. For other platforms compilation is disabled as a precaution.
-@torch.compile(disable=(sys.platform != "linux" and sys.platform != "win32"))
 class GreenFormer(nn.Module):
     def __init__(
         self,

--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import sys
 
 import cv2
 import numpy as np
@@ -46,7 +47,22 @@ class CorridorKeyEngine:
 
         self.model_precision = model_precision
 
-        self.model = self._load_model().to(model_precision)
+        model = self._load_model().to(model_precision)
+
+        # We only tested compilation on windows and linux. For other platforms compilation is disabled as a precaution.
+        if sys.platform == "linux" or sys.platform == "win32":
+            # Try compiling the model. Fallback to eager mode if it fails.
+            try:
+                self.model = torch.compile(model)
+                # Trigger compilation with a dummy input
+                dummy_input = torch.zeros(1, 4, img_size, img_size, dtype=model_precision, device=self.device)
+                with torch.inference_mode():
+                    self.model(dummy_input)
+            except Exception as e:
+                logger.info(f"Model compilation failed with error: {e}")
+                logger.warning("Model compilation failed. Falling back to eager mode.")
+                torch.cuda.empty_cache()
+                self.model = model
 
     def _load_model(self) -> GreenFormer:
         logger.info("Loading CorridorKey from %s", self.checkpoint_path)


### PR DESCRIPTION
## What does this change?
Moves the compilation to the initialization of the engine, with automatic fallback to eager mode on compilation errors

## How was it tested?
I uninstalled the compiler triton from the environment and tried running the model and it successfully defaulted to eager mode.
I also ran into weird Out-of-Memory errors on compilation, but this setup should at worst fall back to eager mode.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
