### PR TITLE
fix: route clip_manager logging through module logger

### DIFF
--- a/clip_manager.py
+++ b/clip_manager.py
@@ -150,7 +150,7 @@ class ClipEntry:
 
         if target_alpha_dir:
             if not os.listdir(target_alpha_dir):
-                logging.warning(f"Clip '{self.name}': AlphaHint directory exists but is empty. Marking for generation.")
+                logger.warning(f"Clip '{self.name}': AlphaHint directory exists but is empty. Marking for generation.")
                 self.alpha_asset = None
             else:
                 # Check for image sequence first
@@ -161,7 +161,7 @@ class ClipEntry:
                     if video_candidates:
                         self.alpha_asset = ClipAsset(os.path.join(target_alpha_dir, video_candidates[0]), "video")
                     else:
-                        logging.warning(
+                        logger.warning(
                             f"Clip '{self.name}': AlphaHint directory has no valid image or video files."
                             " Marking for generation."
                         )
@@ -958,14 +958,11 @@ def scan_clips() -> list[ClipEntry]:
             invalid_clips.append((d, f"Unexpected error: {e}"))
 
     if invalid_clips:
-        print("\n" + "=" * 60)
-        print(" INVALID OR SKIPPED CLIPS")
-        print("=" * 60)
+        logger.warning("INVALID OR SKIPPED CLIPS:")
         for name, reason in invalid_clips:
-            print(f"- {name}: {reason}")
-        print("=" * 60 + "\n")
+            logger.warning("  - %s: %s", name, reason)
     else:
-        print("\nAll clip folders appear valid.\n")
+        logger.info("All clip folders appear valid.")
 
     return valid_clips
 


### PR DESCRIPTION
## What changed

Two logging consistency fixes in `clip_manager.py`, both surgical — no logic changes.

**1. `ClipEntry.find_assets()` — `logging.warning()` → `logger.warning()`**

The module defines `logger = logging.getLogger(__name__)` at line 26, but two call sites in `find_assets()` bypass it, writing directly to the root logger via `logging.warning()`:

- Empty AlphaHint directory warning (was line 153)
- AlphaHint directory with no valid media files warning (was line 164)

These now use the module logger, so they respect the caller's log configuration and show the correct module name (`clip_manager`) in log output.

**2. `scan_clips()` — `print()` → `logger`**

The INVALID OR SKIPPED CLIPS summary and the all-valid confirmation used raw `print()`, which:
- Bypasses log level filtering entirely
- Is invisible to any log handler when `clip_manager` is used as a library
- Cannot be suppressed without redirecting stdout

Replaced with `logger.warning()` per invalid entry and `logger.info()` for the all-valid case.

## Why it was needed

When `clip_manager` is imported and called programmatically (e.g. from `corridorkey_cli.py`), `print()` output goes directly to stdout and cannot be filtered or redirected by the caller's logging setup. The `logging.warning()` calls had the same issue — they wrote to the root logger, not the module logger, making them harder to trace and impossible to suppress per-module.

## How to verify

```bash
uv run pytest          # 221 passed, 2 skipped
uv run ruff check clip_manager.py   # All checks passed
```

No behaviour change in interactive use — log output appears identically at WARNING/INFO level when the root handler is configured (as `corridorkey_cli.py` does via `_configure_environment()`).