### PR TITLE
fix: log on read_video_frame_at failure; os.path.join in stitch_video

### DIFF
--- a/backend/ffmpeg_tools.py
+++ b/backend/ffmpeg_tools.py
@@ -327,7 +327,7 @@ def stitch_video(
         "-start_number",
         "0",
         "-i",
-        in_dir + "/" + pattern,
+        os.path.join(in_dir, pattern),
         "-c:v",
         codec,
         "-crf",

--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -85,6 +85,7 @@ def read_video_frame_at(
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         ret, frame = cap.read()
         if not ret:
+            logger.warning("Could not read video frame %d from: %s", frame_index, video_path)
             return None
         return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
     finally:


### PR DESCRIPTION
## What changed

Two small fixes in `backend/` — no logic changes.

**1. `backend/frame_io.py` — silent `None` in `read_video_frame_at()`**

When `cap.read()` fails (bad seek, truncated video, corrupted file), `read_video_frame_at()` returned `None` with no log output. Its sibling `read_image_frame()` already emits `logger.warning("Could not read frame: %s", fpath)` in the same situation. `read_video_frame_at()` was inconsistent — the failure was completely invisible to callers and log handlers.

Added `logger.warning("Could not read video frame %d from: %s", frame_index, video_path)` immediately before the `return None`, matching the existing pattern.

**2. `backend/ffmpeg_tools.py` — hardcoded `/` in `stitch_video()`**

The FFmpeg `-i` input path was built with string concatenation (`in_dir + "/" + pattern`), the only remaining hardcoded slash in the file after the `os.path.join` fixes in PR #100. Replaced with `os.path.join(in_dir, pattern)`; `os` is already imported at line 15.

## Why it was needed

- Silent `None` returns make debugging failed video reads difficult — there's no log message to indicate which file or frame index caused the problem.
- Hardcoded `/` breaks on Windows paths; the rest of `ffmpeg_tools.py` already uses `os.path.join` consistently.

## How to verify

```bash
uv run pytest          # 221 passed, 2 skipped
uv run ruff check backend/frame_io.py backend/ffmpeg_tools.py   # All checks passed
```