### PR TITLE
feat: add --skip-existing to resume partial renders

### DIFF
--- a/clip_manager.py
+++ b/clip_manager.py
@@ -598,6 +598,7 @@ def run_inference(
     device=None,
     backend=None,
     max_frames=None,
+    skip_existing=False,
     settings: InferenceSettings | None = None,
     *,
     on_clip_start: Callable[[str, int], None] | None = None,
@@ -670,7 +671,23 @@ def run_inference(
         if on_clip_start:
             on_clip_start(clip.name, num_frames)
 
+        skipped_count = 0
+
         for i in range(num_frames):
+            # Pre-compute output stem for skip-existing check (mirrors how input_stem
+            # is set later: video -> zero-padded index, sequence -> file stem)
+            if clip.input_asset.type == "video":
+                expected_stem = f"{i:05d}"
+            else:
+                expected_stem = os.path.splitext(input_files[i])[0]
+
+            if skip_existing and os.path.exists(os.path.join(comp_dir, f"{expected_stem}.png")):
+                logger.debug("Frame %d already rendered, skipping.", i)
+                skipped_count += 1
+                if on_frame_complete:
+                    on_frame_complete(i, num_frames)
+                continue
+
             # 1. Read Input
             img_srgb = None
             input_stem = f"{i:05d}"
@@ -785,6 +802,13 @@ def run_inference(
             input_cap.release()
         if alpha_cap:
             alpha_cap.release()
+
+        if skip_existing and skipped_count > 0:
+            logger.info(
+                "  Skipped %d of %d frames (outputs already exist).",
+                skipped_count,
+                num_frames,
+            )
 
         # 7. Stitch comp frames into MP4 (if input was video)
         if clip.input_asset and clip.input_asset.type == "video":

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -249,6 +249,10 @@ def run_inference_cmd(
         Optional[int],
         typer.Option("--max-frames", help="Limit frames per clip"),
     ] = None,
+    skip_existing: Annotated[
+        bool,
+        typer.Option("--skip-existing", help="Skip frames whose output files already exist (resume a partial render)"),
+    ] = False,
     linear: Annotated[
         Optional[bool],
         typer.Option("--linear/--srgb", help="Input colorspace (default: prompt)"),
@@ -304,6 +308,7 @@ def run_inference_cmd(
             device=ctx.obj["device"],
             backend=backend,
             max_frames=max_frames,
+            skip_existing=skip_existing,
             settings=settings,
             on_clip_start=ctx_progress.on_clip_start,
             on_frame_complete=ctx_progress.on_frame_complete,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,3 +240,18 @@ class TestNonInteractiveFlags:
         assert "--linear" in plain
         assert "--refiner" in plain
         assert "--despeckle-size" in plain
+        assert "--skip-existing" in plain
+
+    @patch("corridorkey_cli.scan_clips")
+    @patch("corridorkey_cli.run_inference")
+    def test_skip_existing_passed_through(self, mock_run, mock_scan):
+        """--skip-existing is forwarded to run_inference as skip_existing kwarg."""
+        mock_scan.return_value = []
+        result = runner.invoke(
+            app,
+            ["run-inference", "--skip-existing", "--srgb", "--despill", "5", "--despeckle", "--refiner", "1.0"],
+        )
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["skip_existing"] is True


### PR DESCRIPTION
## Summary

- Adds `--skip-existing` flag to `run-inference`. When set, any frame whose `Comp/{stem}.png` already exists in the output directory is skipped — no file read, no inference call. Interrupted renders can be resumed without reprocessing completed frames.
- `expected_stem` is pre-computed at the top of the frame loop (before any reads) so the check never touches the existing read path: `{i:05d}` for video, `os.path.splitext(input_files[i])[0]` for sequences — exactly matching how `input_stem` is set later in the loop.
- **Sentinel choice — `Comp/{stem}.png`:** always written (not conditional on `res` keys like `Processed`), and written *after* `FG.exr` and `Matte.exr`, so its presence implies all guaranteed outputs exist. Single `os.path.exists()` call per frame.
- Skipped frames still call `on_frame_complete` so the progress bar advances correctly and ETA stays accurate.
- Per-clip INFO summary: `Skipped N of M frames (outputs already exist).` — per-frame logging is at DEBUG to avoid flooding long runs.
- 222 tests pass (1 new: `--skip-existing` kwarg passthrough; 1 extended: help flag assertion).

## Why it was needed

Long renders (500–2000 frames) can be interrupted by power loss, system sleep, or user cancellation. Without `--skip-existing`, re-running redoes all work from frame 0. This change makes renders safely resumable at zero cost when not needed (default `False`).

## How to verify

```bash
uv run pytest --tb=short -q
uv run corridorkey run-inference --help   # --skip-existing appears in output
```

Manual (with clips present):
```bash
# Run a partial render, then interrupt (Ctrl-C)
uv run corridorkey run-inference --max-frames 10 --srgb --despill 5 --despeckle --refiner 1.0

# Resume — first 10 frames are skipped, rest continue
uv run corridorkey run-inference --skip-existing --srgb --despill 5 --despeckle --refiner 1.0
```