### PR TITLE
fix: update issue templates for bug reporting with required fields an…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,6 +20,7 @@ body:
       label: Operating System
       description: Your operating system and version.
       placeholder: "Windows 11, macOS 14.2, Ubuntu 22.04 LTS"
+    validations:
       required: true
 
   - type: input
@@ -28,6 +29,7 @@ body:
       label: Installation Method
       description: How did you install CorridorKey? (e.g., Windows batch installer, `uv sync`, Docker, manual setup)
       placeholder: "Windows batch installer, uv sync --extra cuda, Docker"
+    validations:
       required: true
 
   - type: input
@@ -36,6 +38,7 @@ body:
       label: GPU/Hardware (Optional)
       description: GPU model and VRAM if applicable, or other relevant hardware constraints.
       placeholder: "NVIDIA RTX 4090 (24GB), Apple M3 Pro (18GB unified memory)"
+    validations:
       required: true
 
   - type: textarea
@@ -49,6 +52,7 @@ body:
         3. Step 3
         4. Step 4
         5. Error occurs
+    validations:
       required: true
 
   - type: textarea
@@ -57,6 +61,7 @@ body:
       label: Expected Behavior
       description: What should happen instead? Be clear and concise.
       placeholder: "The application should display a settings panel without errors."
+    validations:
       required: false
 
   - type: textarea
@@ -65,6 +70,7 @@ body:
       label: Actual Behavior
       description: What happened instead? Describe the bug clearly and concisely.
       placeholder: "The application crashes with an Error"
+    validations:
       required: true
 
   - type: textarea
@@ -83,6 +89,7 @@ body:
       label: Workaround (if available)
       description: If you've found a way to work around this issue, please describe it.
       placeholder: "As a workaround, I can set the timeout environment variable before starting the app."
+    validations:
       required: false
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,66 +1,69 @@
-name: 💡 Feature Request
-description: Suggest a new idea, enhancement, or improvement.
-title: "[Feature]: "
-labels: [enhancement]
+name: 🐛 Bug Report
+description: Report a reproducible issue or unexpected behavior in the project.
+title: "[Bug]: "
+labels: [bug]
 
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting a feature! Before submitting, please check if a similar request already exists.
-
-        **Good feature requests are:**
-        - Clear and descriptive
-        - Focused on solving a specific problem
-        - Documented with examples when helpful
+        Thanks for reporting a bug! Please fill out the form below so we can investigate the issue.
 
   - type: input
-    id: motivation
+    id: environment
     attributes:
-      label: Problem or Motivation
-      description: What problem does this solve, or what's the motivation behind it?
-      placeholder: "Currently, I have to manually... It would be great if..."
+      label: Environment
+      description: Relevant environmental details (OS, version, tools, etc.)
+      placeholder: "e.g. Ubuntu 22.04, macOS 13, Docker, etc."
+    validations:
       required: true
 
   - type: textarea
-    id: proposal
+    id: steps
     attributes:
-      label: Proposed Solution
-      description: Describe how you'd like this feature to work.
-      placeholder: "Add a new flag to support... or integrate with... or expose a method to..."
+      label: Steps to Reproduce
+      description: Describe the steps to trigger the issue. Be as specific as possible.
+      placeholder: |
+        1. Do '...'
+        2. Then do '...'
+        3. Observe '...'
+    validations:
       required: true
 
   - type: textarea
-    id: alternatives
+    id: expected
     attributes:
-      label: Alternatives Considered
-      description: Have you considered other solutions or approaches? Explain why the proposed solution is preferable.
-      placeholder: "I considered using X instead, but Y would be better because..."
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
 
   - type: textarea
-    id: context
+    id: actual
     attributes:
-      label: Additional Context
-      description: Add any screenshots, links, or other helpful references (optional).
-      placeholder: "Screenshots, related discussions, or examples..."
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs or Screenshots
+      description: Paste error logs or screenshots here, if any.
+      placeholder: |
+        ```
+        Error output or logs here
+        ```
+    validations:
       required: false
 
   - type: checkboxes
-    id: checklist
+    id: checks
     attributes:
-      label: Prerequisites
+      label: Checklist
       options:
-        - label: I have searched for existing feature requests and found none
+        - label: I’ve verified this bug hasn’t been reported before.
           required: true
-        - label: This feature is not already in progress or planned
+        - label: I’ve included all relevant logs/screenshots/configs.
           required: true
-
-  - type: checkboxes
-    id: agreement
-    attributes:
-      label: Agreement
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true
-        - label: I understand this feature will be reviewed and may not be implemented
-          required: false


### PR DESCRIPTION
## What does this change?

GitHub had changed the schema for issue templates for which the previous templates had critical errors. I have fixed the following errors in this PR.

<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/f57524ae-c53a-473a-ac74-39339f17c7ea" />
<img width="1920" height="951" alt="image" src="https://github.com/user-attachments/assets/2fc6fc24-4c3d-4cdd-8ccb-4539a1e678e6" />

## How was it tested?

Not required

## Checklist

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` passes
- [ ] `uv run ruff format --check` passes
