### PR TITLE
fix: use correct PyTorch attribute total_memory in VRAM query

### DIFF
--- a/backend/service.py
+++ b/backend/service.py
@@ -193,7 +193,7 @@ class CorridorKeyService:
             if not torch.cuda.is_available():
                 return {}
             props = torch.cuda.get_device_properties(0)
-            total_bytes = props.total_mem
+            total_bytes = props.total_memory
             reserved = torch.cuda.memory_reserved(0)
             return {
                 "total": total_bytes / (1024**3),


### PR DESCRIPTION
`torch.cuda.get_device_properties().total_mem` does not exist — the correct attribute is `total_memory`. The typo causes an AttributeError that is silently swallowed, making `get_vram_info()` always return an empty dict on CUDA systems.