### PR TITLE
feat: add progress_callback to GVM process_sequence

### DIFF
--- a/gvm_core/wrapper.py
+++ b/gvm_core/wrapper.py
@@ -114,7 +114,8 @@ class GVMProcessor:
                          noise_type='zeros',
                          mode='matte',
                          write_video=True,
-                         direct_output_dir=None):
+                         direct_output_dir=None,
+                         progress_callback=None):
         """
         Process a single video or directory of images.
         """
@@ -274,6 +275,9 @@ class GVMProcessor:
 
             if writer_alpha: writer_alpha.write(alpha)
             writer_alpha_seq.write(alpha, filenames=filenames)
+
+            if progress_callback is not None:
+                progress_callback(batch_id + 1, len(dataloader))
         
         if writer_alpha: writer_alpha.close()
         writer_alpha_seq.close()


### PR DESCRIPTION
Adds an optional progress_callback parameter to
GVMProcessor.process_sequence(). Called after each batch with (current_batch, total_batches). Backwards-compatible — defaults to None with no behavior change when not passed.

This enables callers (CLI, WebUI, etc.) to report per-batch progress during GVM alpha generation.
