### PR TITLE
Normalize mixed-case auto device selection

### DIFF
--- a/device_utils.py
+++ b/device_utils.py
@@ -31,9 +31,9 @@ def resolve_device(requested: str | None = None) -> str:
         RuntimeError: If the requested backend is unavailable.
     """
     # CLI arg takes priority, then env var, then auto
-    device = requested
+    device = requested.strip().lower() if requested is not None else None
     if device is None or device == "auto":
-        device = os.environ.get(DEVICE_ENV_VAR, "auto")
+        device = os.environ.get(DEVICE_ENV_VAR, "auto").strip().lower()
 
     if device == "auto":
         return detect_best_device()

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -72,6 +72,11 @@ class TestResolveDevice:
         monkeypatch.delenv(DEVICE_ENV_VAR, raising=False)
         assert resolve_device("auto") == "cuda"
 
+    def test_auto_string_is_case_insensitive(self, monkeypatch):
+        _patch_gpu(monkeypatch, cuda=True)
+        monkeypatch.delenv(DEVICE_ENV_VAR, raising=False)
+        assert resolve_device(" AUTO ") == "cuda"
+
     # --- env var fallback ---
 
     def test_env_var_used_when_no_cli_arg(self, monkeypatch):
@@ -82,6 +87,11 @@ class TestResolveDevice:
     def test_env_var_auto_triggers_detect(self, monkeypatch):
         _patch_gpu(monkeypatch, cuda=False, mps=True)
         monkeypatch.setenv(DEVICE_ENV_VAR, "auto")
+        assert resolve_device(None) == "mps"
+
+    def test_env_var_auto_is_case_insensitive(self, monkeypatch):
+        _patch_gpu(monkeypatch, cuda=False, mps=True)
+        monkeypatch.setenv(DEVICE_ENV_VAR, " AUTO ")
         assert resolve_device(None) == "mps"
 
     # --- CLI arg overrides env var ---


### PR DESCRIPTION
## Summary
- normalize `requested` device strings before the `auto` branch runs
- normalize the env var fallback the same way so `AUTO` and surrounding whitespace still trigger detection
- add focused tests for mixed-case/space-padded `auto` inputs

## Verification
- direct Python behavior check with a stubbed `torch` module (the local environment does not have project dependencies like `torch` or `pytest` installed)