### PR TITLE
Fix for Issue #205

### DIFF
--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -144,9 +144,7 @@ def _prompt_inference_settings(
     """Interactively prompt for inference settings, skipping any pre-filled values."""
     console.print(Panel("Inference Settings", style="bold cyan"))
     generate_comp = default_comp if default_comp is not None else InferenceSettings.generate_comp
-    gpu_post_processing = (
-        default_gpu_post if default_gpu_post is not None else InferenceSettings.gpu_post_processing
-    )
+    gpu_post_processing = default_gpu_post if default_gpu_post is not None else InferenceSettings.gpu_post_processing
 
     if default_linear is not None:
         input_is_linear = default_linear

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -143,6 +143,10 @@ def _prompt_inference_settings(
 ) -> InferenceSettings:
     """Interactively prompt for inference settings, skipping any pre-filled values."""
     console.print(Panel("Inference Settings", style="bold cyan"))
+    generate_comp = default_comp if default_comp is not None else InferenceSettings.generate_comp
+    gpu_post_processing = (
+        default_gpu_post if default_gpu_post is not None else InferenceSettings.gpu_post_processing
+    )
 
     if default_linear is not None:
         input_is_linear = default_linear


### PR DESCRIPTION
Prevent `_prompt_inference_settings()` from raising `UnboundLocalError` when the resolved backend is not `torch` (for MLX on Apple Silicon).

The function always returned `InferenceSettings`, but `generate_comp` and `gpu_post_processing` were only assigned inside the torch-specific branch. On MLX this left both locals undefined and caused inference to crash before startup.

Initialize those fields from `InferenceSettings` defaults before the backend check, then continue overriding them only for the torch path.

prompt helper returns valid settings instead of crashing.

## What does this change?

- Initializes generate_comp and gpu_post_processing before backend-specific prompting.

- Preserves existing torch behavior: torch users are still prompted for composition preview and GPU post-processing settings.

- Makes non-torch backend MLX fall back to the InferenceSettings defaults instead of crashing.

## Checklist

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` passes
- [ ] `uv run ruff format --check` passes
