### PR TITLE
feat: MSVC auto-detection + C compiler check before torch.compile

### DIFF
--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -24,6 +24,31 @@ os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", _inductor_cache)
 logger = logging.getLogger(__name__)
 
 
+def _try_activate_msvc() -> None:
+    """Find and activate MSVC (cl.exe) on Windows if installed but not in PATH.
+
+    Searches common Visual Studio install locations for the latest cl.exe
+    and adds its directory to PATH.
+    """
+    import glob
+
+    patterns = [
+        r"C:\Program Files\Microsoft Visual Studio\2022\*\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe",
+        r"C:\Program Files (x86)\Microsoft Visual Studio\2022\*\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe",
+        r"C:\Program Files\Microsoft Visual Studio\2019\*\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe",
+    ]
+
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern), reverse=True)  # newest version first
+        if matches:
+            cl_dir = os.path.dirname(matches[0])
+            os.environ["PATH"] = cl_dir + os.pathsep + os.environ.get("PATH", "")
+            logger.info("Auto-detected MSVC: %s", matches[0])
+            return
+
+    logger.debug("MSVC not found in standard locations")
+
+
 class CorridorKeyEngine:
     def __init__(
         self,
@@ -58,12 +83,29 @@ class CorridorKeyEngine:
         self._is_rocm = hasattr(torch.version, "hip") and torch.version.hip
         self.model = self._load_model()
 
-        # torch.compile is tested on CUDA (Windows + Linux) and ROCm (Linux).
-        # ROCm on Windows hangs during Triton kernel compilation — skip it.
-        # CORRIDORKEY_SKIP_COMPILE=1 forces eager mode (useful for testing).
-        skip_compile = (self._is_rocm and sys.platform == "win32") or os.environ.get("CORRIDORKEY_SKIP_COMPILE") == "1"
-        if skip_compile:
-            logger.info("Skipping torch.compile (eager mode)")
+        # torch.compile needs: cl.exe (Windows), gcc (Linux), and Triton.
+        # Check prerequisites and skip with a helpful message if missing.
+        import shutil
+
+        # Auto-detect MSVC on Windows — it's installed but not in PATH by default
+        if sys.platform == "win32" and not shutil.which("cl"):
+            _try_activate_msvc()
+
+        skip_reason = None
+        if self._is_rocm and sys.platform == "win32":
+            skip_reason = "ROCm on Windows — Triton compilation hangs"
+        elif os.environ.get("CORRIDORKEY_SKIP_COMPILE") == "1":
+            skip_reason = "CORRIDORKEY_SKIP_COMPILE=1"
+        elif sys.platform == "win32" and not shutil.which("cl"):
+            skip_reason = (
+                "MSVC (cl.exe) not found. Install Visual Studio Build Tools "
+                "for ~30% faster inference: https://visualstudio.microsoft.com/visual-cpp-build-tools/"
+            )
+        elif sys.platform == "linux" and not shutil.which("gcc") and not shutil.which("cc"):
+            skip_reason = "no C compiler found — install gcc for faster inference"
+
+        if skip_reason:
+            logger.info("Skipping torch.compile (%s)", skip_reason)
         elif sys.platform == "linux" or sys.platform == "win32":
             self._compile()
 


### PR DESCRIPTION
## MSVC auto-detection + C compiler check before torch.compile

`torch.compile` needs a C compiler (cl.exe on Windows, gcc on Linux). On Windows, Visual Studio Build Tools installs cl.exe but doesn't add it to PATH — users get a cryptic compilation failure and fall back to eager mode (~30% slower) without knowing why.

- Auto-detect MSVC in standard Visual Studio 2019/2022 install locations
- Check for C compiler before attempting compile
- Show actionable message with install link if missing
- Skip reasons are logged clearly instead of generic "compilation failed"

## What does this change?

Replaces the simple `skip_compile` boolean with a prerequisite check that:
1. On Windows: searches for cl.exe in VS install paths and adds it to PATH automatically
2. If no compiler found: logs a clear message with install link instead of attempting compile and failing cryptically
3. On Linux: checks for gcc/cc before attempting compile

Only touches `CorridorKeyModule/inference_engine.py`. No new dependencies.

## How was it tested?

- Tested on Windows with VS Build Tools installed (cl.exe auto-detected, compile succeeds)
- Tested on Windows without VS Build Tools (clear skip message logged, falls back to eager)
- Tested on Linux with gcc (compile succeeds as before)
- Tested on Linux Docker without gcc (clear skip message, falls back to eager)

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
