### PR TITLE
Fix clean matte not actually removing some blobs on GPU

### DIFF
--- a/CorridorKeyModule/core/color_utils.py
+++ b/CorridorKeyModule/core/color_utils.py
@@ -279,19 +279,15 @@ def connected_components(mask: torch.Tensor, min_component_width=1, max_iteratio
 
     # Reference implementation uses torch.arange instead of torch.randperm
     # torch.randperm converges considerably faster and more uniformly
-    comp = (torch.randperm(W * H) + 1).repeat(bs, 1).view(mask.shape).float().to(mask.device)
+    # If the batch size is >2 at 4k, float32 can't exactly represent all pixel indices (only up to 2^24)
+    # We add 0.1 to ensure all floats get floored to unique integers
+    comp = (torch.randperm(bs * W * H, device=mask.device, dtype=torch.float32) + 1.1).view(mask.shape)
     comp[mask != 1] = 0
 
-    prev_comp = torch.zeros_like(comp)
-
-    iteration = 0
-
-    while not torch.equal(comp, prev_comp) and iteration < max_iterations:
-        prev_comp = comp.clone()
+    for _ in range(max_iterations):
         comp[mask == 1] = F.max_pool2d(
             comp, kernel_size=(2 * min_component_width) + 1, stride=1, padding=min_component_width
         )[mask == 1]
-        iteration += 1
 
     comp = comp.long()
     # Relabel components to have contiguous labels starting from 1
@@ -362,12 +358,13 @@ def clean_matte_torch(alpha: torch.Tensor, area_threshold: int, dilation: int, b
     Supports fully running on the GPU
     alpha_np: torch Tensor [B, 1, H, W] (0.0 - 1.0)
     """
-    _device = alpha.device
     mask = alpha > 0.5  # [B, 1, H, W]
 
     # Find the largest connected components in the mask
     # only a limited amount of iterations is needed to find components above the area threshold
     components = connected_components(mask, max_iterations=area_threshold // 8, min_component_width=2)
+
+    # We can use bincount even for batched inputs because the areas are uniquely labeled across the entire batch
     sizes = torch.bincount(components.flatten())
     big_sizes = torch.nonzero(sizes >= area_threshold)
 

--- a/CorridorKeyModule/core/color_utils.py
+++ b/CorridorKeyModule/core/color_utils.py
@@ -265,12 +265,12 @@ def despill_torch(image: torch.Tensor, strength: float) -> torch.Tensor:
     return despilled
 
 
-def connected_components(mask: torch.Tensor, min_component_width=1, max_iterations=100) -> torch.Tensor:
+def connected_components(mask: torch.Tensor, min_component_distance=1, max_iterations=100) -> torch.Tensor:
     """
     Adapted from: https://gist.github.com/efirdc/5d8bd66859e574c683a504a4690ae8bc
     Args:
         mask: torch Tensor [B, 1, H, W] binary 1 or 0
-        min_component_width: int. Minimum width of connected components that are separated instead of merged.
+        min_component_distance: int. Minimum distance between connected components that are separated instead of merged.
         max_iterations: int. Maximum number of flood fill iterations. Adjust based on expected component sizes.
     Returns:
         comp: torch Tensor [B, 1, H, W] with connected component labels (0 = background, 1..N = components)
@@ -286,7 +286,7 @@ def connected_components(mask: torch.Tensor, min_component_width=1, max_iteratio
 
     for _ in range(max_iterations):
         comp[mask == 1] = F.max_pool2d(
-            comp, kernel_size=(2 * min_component_width) + 1, stride=1, padding=min_component_width
+            comp, kernel_size=(2 * min_component_distance) + 1, stride=1, padding=min_component_distance
         )[mask == 1]
 
     comp = comp.long()
@@ -352,17 +352,17 @@ def clean_matte_opencv(
     return result_alpha
 
 
-def clean_matte_torch(alpha: torch.Tensor, area_threshold: int, dilation: int, blur_size: int) -> torch.Tensor:
+def clean_matte_torch(alpha: torch.Tensor, area_threshold: int, dilation: int = 15, blur_size: int = 5) -> torch.Tensor:
     """
     Cleans up small disconnected components (like tracking markers) from a predicted alpha matte.
     Supports fully running on the GPU
     alpha_np: torch Tensor [B, 1, H, W] (0.0 - 1.0)
     """
-    mask = alpha > 0.5  # [B, 1, H, W]
+    mask = alpha > 0.25  # [B, 1, H, W]
 
     # Find the largest connected components in the mask
     # only a limited amount of iterations is needed to find components above the area threshold
-    components = connected_components(mask, max_iterations=area_threshold // 8, min_component_width=2)
+    components = connected_components(mask, max_iterations=area_threshold // 20, min_component_distance=4)
 
     # We can use bincount even for batched inputs because the areas are uniquely labeled across the entire batch
     sizes = torch.bincount(components.flatten())

--- a/CorridorKeyModule/core/color_utils.py
+++ b/CorridorKeyModule/core/color_utils.py
@@ -296,6 +296,9 @@ def connected_components(mask: torch.Tensor, min_component_width=1, max_iteratio
     comp = comp.long()
     # Relabel components to have contiguous labels starting from 1
     unique_labels = torch.unique(comp)
+    # Add background label (0) if not present
+    if unique_labels[0] != 0:
+        unique_labels = torch.cat([torch.tensor([0], device=mask.device), unique_labels])
     label_map = torch.zeros(unique_labels.max().item() + 1, dtype=torch.long, device=mask.device)
     label_map[unique_labels] = torch.arange(len(unique_labels), device=mask.device)
     comp = label_map[comp]
@@ -369,6 +372,8 @@ def clean_matte_torch(alpha: torch.Tensor, area_threshold: int, dilation: int, b
     big_sizes = torch.nonzero(sizes >= area_threshold)
 
     mask = torch.zeros_like(mask, dtype=torch.float32)
+    # Remove background label (0) if present
+    big_sizes = big_sizes[big_sizes > 0]
     mask[torch.isin(components, big_sizes)] = 1.0
 
     # Dilate back to restore edges of large regions

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -243,10 +243,15 @@ class TestDespill:
     redistributes the removed energy to preserve luminance.
     """
 
-    def test_pure_green_reduced_average_mode_numpy(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_pure_green_reduced_average_mode_numpy(self, backend):
         """A pure green pixel should have green clamped to (R+B)/2 = 0."""
         img = _to_np([[0.0, 1.0, 0.0]])
-        result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        if backend == "openCV":
+            result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        else:
+            img_t = torch.from_numpy(img)
+            result = cu.despill_torch(img_t, strength=1.0).numpy()
         # Green should be 0 (clamped to avg of R=0, B=0)
         assert result[0, 1] == pytest.approx(0.0, abs=1e-6)
 
@@ -256,22 +261,37 @@ class TestDespill:
         result = cu.despill_opencv(img, green_limit_mode="max", strength=1.0)
         assert result[0, 1] == pytest.approx(0.0, abs=1e-6)
 
-    def test_pure_red_unchanged_numpy(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_pure_red_unchanged_numpy(self, backend):
         """A pixel with no green excess should not be modified."""
         img = _to_np([[1.0, 0.0, 0.0]])
-        result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        if backend == "openCV":
+            result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        else:
+            img_t = torch.from_numpy(img)
+            result = cu.despill_torch(img_t, strength=1.0).numpy()
         np.testing.assert_allclose(result, img, atol=1e-6)
 
-    def test_strength_zero_is_noop_numpy(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_strength_zero_is_noop_numpy(self, backend):
         """strength=0 should return the input unchanged."""
         img = _to_np([[0.2, 0.9, 0.1]])
-        result = cu.despill_opencv(img, strength=0.0)
+        if backend == "openCV":
+            result = cu.despill_opencv(img, strength=0.0)
+        else:
+            img_t = torch.from_numpy(img)
+            result = cu.despill_torch(img_t, strength=0.0).numpy()
         np.testing.assert_allclose(result, img, atol=1e-7)
 
-    def test_partial_green_average_mode_numpy(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_partial_green_average_mode_numpy(self, backend):
         """Green slightly above (R+B)/2 should be reduced, not zeroed."""
         img = _to_np([[0.4, 0.8, 0.2]])
-        result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        if backend == "openCV":
+            result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        else:
+            img_t = torch.from_numpy(img)
+            result = cu.despill_torch(img_t, strength=1.0).numpy()
         limit = (0.4 + 0.2) / 2.0  # 0.3
         expected_green = limit  # green clamped to limit
         assert result[0, 1] == pytest.approx(expected_green, abs=1e-5)
@@ -284,11 +304,17 @@ class TestDespill:
         # max(R,B)=0.6 vs avg(R,B)=0.35, so max mode removes less green
         assert result_max[0, 1] >= result_avg[0, 1]
 
-    def test_fractional_strength_interpolates(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_fractional_strength_interpolates(self, backend):
         """strength=0.5 should produce a result between original and fully despilled."""
         img = _to_np([[0.2, 0.9, 0.1]])
-        full = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
-        half = cu.despill_opencv(img, green_limit_mode="average", strength=0.5)
+        if backend == "openCV":
+            full = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+            half = cu.despill_opencv(img, green_limit_mode="average", strength=0.5)
+        else:
+            img_t = torch.from_numpy(img)
+            full = cu.despill_torch(img_t, strength=1.0).numpy()
+            half = cu.despill_torch(img_t, strength=0.5).numpy()
         # Half-strength green should be between original green and fully despilled green
         assert half[0, 1] < img[0, 1]  # less green than original
         assert half[0, 1] > full[0, 1]  # more green than full despill
@@ -304,7 +330,8 @@ class TestDespill:
         result_t = cu.despill_opencv(img_t, green_limit_mode="average", strength=1.0)
         np.testing.assert_allclose(result_np, result_t.numpy(), atol=1e-5)
 
-    def test_green_below_limit_unchanged_numpy(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_green_below_limit_unchanged_numpy(self, backend):
         """spill_amount is clamped to zero when G < (R+B)/2 — pixel is returned unchanged.
 
         When a pixel has less green than the luminance limit ((R+B)/2) it
@@ -315,7 +342,11 @@ class TestDespill:
         # G=0.3 is well below the average limit (0.8+0.6)/2 = 0.7
         # spill_amount = max(0.3 - 0.7, 0) = 0  →  output equals input
         img = _to_np([[0.8, 0.3, 0.6]])
-        result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        if backend == "openCV":
+            result = cu.despill_opencv(img, green_limit_mode="average", strength=1.0)
+        else:
+            img_t = torch.from_numpy(img)
+            result = cu.despill_torch(img_t, strength=1.0).numpy()
         np.testing.assert_allclose(result, img, atol=1e-6)
 
 
@@ -331,22 +362,33 @@ class TestCleanMatte:
     while large foreground regions are preserved.
     """
 
-    def test_large_blob_preserved(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_large_blob_preserved(self, backend):
         """A single large opaque region should survive cleanup."""
         matte = np.zeros((100, 100), dtype=np.float32)
         matte[20:80, 20:80] = 1.0  # 60x60 = 3600 pixels
-        result = cu.clean_matte_opencv(matte, area_threshold=300)
+        if backend == "openCV":
+            result = cu.clean_matte_opencv(matte, area_threshold=300)
+        else:
+            matte = torch.from_numpy(matte).unsqueeze(0).unsqueeze(0)
+            result = cu.clean_matte_torch(matte, area_threshold=300).squeeze(0).squeeze(0).numpy()
         # Center of the blob should still be opaque
         assert result[50, 50] > 0.9
 
-    def test_small_blob_removed(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_small_blob_removed(self, backend):
         """A tiny blob below the threshold should be removed."""
         matte = np.zeros((100, 100), dtype=np.float32)
         matte[5:8, 5:8] = 1.0  # 3x3 = 9 pixels
-        result = cu.clean_matte_opencv(matte, area_threshold=300)
+        if backend == "openCV":
+            result = cu.clean_matte_opencv(matte, area_threshold=300)  #
+        else:
+            matte = torch.from_numpy(matte).unsqueeze(0).unsqueeze(0)
+            result = cu.clean_matte_torch(matte, area_threshold=300).squeeze(0).squeeze(0).numpy()
         assert result[6, 6] == pytest.approx(0.0, abs=1e-5)
 
-    def test_mixed_blobs(self):
+    @pytest.mark.parametrize("backend", ["openCV", "torch"])
+    def test_mixed_blobs(self, backend):
         """Large blob kept, small blob removed."""
         matte = np.zeros((200, 200), dtype=np.float32)
         # Large blob: 50x50 = 2500 px
@@ -354,7 +396,11 @@ class TestCleanMatte:
         # Small blob: 5x5 = 25 px
         matte[150:155, 150:155] = 1.0
 
-        result = cu.clean_matte_opencv(matte, area_threshold=100)
+        if backend == "openCV":
+            result = cu.clean_matte_opencv(matte, area_threshold=100)
+        else:
+            matte = torch.from_numpy(matte).unsqueeze(0).unsqueeze(0)
+            result = cu.clean_matte_torch(matte, area_threshold=100).squeeze(0).squeeze(0).numpy()
         assert result[35, 35] > 0.9  # large blob center preserved
         assert result[152, 152] < 0.01  # small blob removed
 


### PR DESCRIPTION
## What does this change?
- fix despeckle not respecting background on GPU
- add test variants for the torch implementations of clean_matte and despill
- fix batch processing capability of clean_matte_torch
- remove the convergence check of the connected component method because it will never actually hit in a real scenario (It usually converges after 2000-4000 iterations at 4k, while we usually only do ~50)
- tweak alpha threshold and component distance to reduce speckle false positives

We could likely tune the alpha threshold and the minimum component distance even further to improve despeckle quality.
From my understanding the expected speckles are a result of tracking markers on the green screen, which means they are a continuous blob. If blobs are only a few pixels apart they are probably related and can be merged, which gives them a higher chance being preserved by the minimum speckle size.

Likewise we could probably lower the alpha threshold even more (I don't know if 0.5 was chosen for a specific reason). 
We could probably lower the threshold to be just above the model noise floor. An optimal value would need more testing though.

## How was it tested?

### Difference between post-processing on main vs new update


<img width="4096" height="2160" alt="02_3c_00000" src="https://github.com/user-attachments/assets/daacc882-cd65-4c90-91d6-552a2cb412c9" />

<img width="4096" height="2160" alt="02_3c_00000" src="https://github.com/user-attachments/assets/792b7034-7535-4243-bc46-85bda203c9c4" />

<img width="4096" height="2160" alt="diff_02_3c_00000" src="https://github.com/user-attachments/assets/9737ad6f-0ef3-4aba-81c6-af2a8d78221c" />



## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
