### PR TITLE
[Bugfix] Win_path is enforced as directory path, not file path

### DIFF
--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -377,17 +377,19 @@ def wizard(
 # Wizard (rich-styled)
 # ---------------------------------------------------------------------------
 
-# Presume the win_path is a directory. If we are provided with an actual footage content, then we'll use the content's parent directory instead.
+
 def interactive_wizard(win_path: str, device: str | None = None) -> None:
     console.print(Panel("[bold]CORRIDOR KEY — SMART WIZARD[/bold]", style="cyan"))
 
     # 1. Resolve Path
     console.print(f"Windows Path: {win_path}")
 
-    # Perform a check, if we expect user to provide us directory, but accidentially gave us the path to the footage instead, we should presume the parent folder as substitution instead.
+    # Perform a check, if we expect user to provide us directory,
+    # but accidentially gave us the path to the footage instead,
+    # we should presume the parent folder as substitution instead.
     if os.path.isfile(win_path):
         win_path = os.path.abspath(os.path.join(win_path, os.pardir))
-    
+
     if os.path.exists(win_path):
         process_path = win_path
         console.print(f"Running locally: [bold]{process_path}[/bold]")

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -377,13 +377,17 @@ def wizard(
 # Wizard (rich-styled)
 # ---------------------------------------------------------------------------
 
-
+# Presume the win_path is a directory. If we are provided with an actual footage content, then we'll use the content's parent directory instead.
 def interactive_wizard(win_path: str, device: str | None = None) -> None:
     console.print(Panel("[bold]CORRIDOR KEY — SMART WIZARD[/bold]", style="cyan"))
 
     # 1. Resolve Path
     console.print(f"Windows Path: {win_path}")
 
+    # Perform a check, if we expect user to provide us directory, but accidentially gave us the path to the footage instead, we should presume the parent folder as substitution instead.
+    if os.path.isfile(win_path):
+        win_path = os.path.abspath(os.path.join(win_path, os.pardir))
+    
     if os.path.exists(win_path):
         process_path = win_path
         console.print(f"Running locally: [bold]{process_path}[/bold]")


### PR DESCRIPTION
## What does this change?
This change aims to reduce the confusion when user drags and drop a footage/file instead of a directory as instructed. This brings upsetting clients to discord server and ask why this program breaks. 

https://discord.com/channels/1128442184715214980/1476324228834791474/1477023833729794222

This pull request changes how interactive wizard process the win_path parameter. Since we are making the assumption that this input is a directory in the logic down below, we'll fetch the parent directory from the dropped file.  

## How was it tested?
Dragging a footage will open the interactive wizard into the parent directory instead.
Also ran `uv run pytest && uv run ruff check && uv run ruff format --check` and all passed.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
