### PR TITLE
feat: Add CLI arguments for image size and MLX tiled inference

### DIFF
--- a/clip_manager.py
+++ b/clip_manager.py
@@ -40,6 +40,8 @@ class InferenceSettings:
     refiner_scale: float = 1.0
     generate_comp: bool = True
     gpu_post_processing: bool = False
+    image_size: int = 2048
+    tiled_inference: bool = False
 
 
 # Core Paths
@@ -626,9 +628,14 @@ def run_inference(
 
     if device is None:
         device = resolve_device()
-    from CorridorKeyModule.backend import create_engine
+    from CorridorKeyModule.backend import DEFAULT_MLX_TILE_SIZE, create_engine
 
-    engine = create_engine(backend=backend, device=device)
+    engine = create_engine(
+        backend=backend,
+        device=device,
+        tile_size=DEFAULT_MLX_TILE_SIZE if settings.tiled_inference else None,
+        img_size=settings.image_size,
+    )
 
     for clip in ready_clips:
         logger.info(f"Running Inference on: {clip.name}")

--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -153,11 +153,16 @@ def _prompt_inference_settings(
     default_refiner: float | None = None,
     default_comp: bool | None = None,
     default_gpu_post: bool | None = None,
+    default_image_size: int | None = None,
+    default_tiled_inference: bool | None = None,
 ) -> InferenceSettings:
     """Interactively prompt for inference settings, skipping any pre-filled values."""
     console.print(Panel("Inference Settings", style="bold cyan"))
     generate_comp = default_comp if default_comp is not None else InferenceSettings.generate_comp
     gpu_post_processing = default_gpu_post if default_gpu_post is not None else InferenceSettings.gpu_post_processing
+    tiled_inference = (
+        default_tiled_inference if default_tiled_inference is not None else InferenceSettings.tiled_inference
+    )
 
     if default_linear is not None:
         input_is_linear = default_linear
@@ -195,6 +200,15 @@ def _prompt_inference_settings(
         )
         despeckle_size = max(0, despeckle_size)
 
+    if default_image_size is not None:
+        image_size = default_image_size
+    else:
+        image_size = Prompt.ask("Inference image size", choices=["512", "1024", "2048"], default="2048")
+        try:
+            image_size = int(image_size)
+        except ValueError:
+            image_size = 2048
+
     if default_refiner is not None:
         refiner_scale = default_refiner
     else:
@@ -207,7 +221,18 @@ def _prompt_inference_settings(
         except ValueError:
             refiner_scale = 1.0
 
-    if resolve_backend() == "torch":
+    backend = resolve_backend()
+
+    if backend == "mlx":
+        if default_tiled_inference is not None:
+            tiled_inference = default_tiled_inference
+        else:
+            tiled_inference = Confirm.ask(
+                "Use mlx tiled inference",
+                default=False,
+            )
+
+    if backend == "torch":
         if default_comp is not None:
             generate_comp = default_comp
         else:
@@ -232,6 +257,8 @@ def _prompt_inference_settings(
         refiner_scale=refiner_scale,
         generate_comp=generate_comp,
         gpu_post_processing=gpu_post_processing,
+        image_size=image_size,
+        tiled_inference=tiled_inference,
     )
 
 
@@ -306,6 +333,10 @@ def run_inference_cmd(
         Optional[int],
         typer.Option("--despeckle-size", help="Min pixel size for despeckle (default: prompt)"),
     ] = None,
+    image_size: Annotated[
+        Optional[int],
+        typer.Option("--image-size", help="Inference image size"),
+    ] = None,
     refiner: Annotated[
         Optional[float],
         typer.Option("--refiner", help="Refiner strength multiplier (default: prompt)"),
@@ -317,6 +348,10 @@ def run_inference_cmd(
     gpu_post: Annotated[
         Optional[bool],
         typer.Option("--gpu-post/--cpu-post", help="Use GPU post-processing (default: prompt)"),
+    ] = None,
+    tiled_inference: Annotated[
+        Optional[bool],
+        typer.Option("--tile/--no-tile", help="Use mlx tiled inference (default: prompt)"),
     ] = None,
 ) -> None:
     """Run CorridorKey inference on clips with Input + AlphaHint.
@@ -337,6 +372,10 @@ def run_inference_cmd(
             auto_despeckle=despeckle,
             despeckle_size=despeckle_size if despeckle_size is not None else 400,
             refiner_scale=refiner,
+            generate_comp=generate_comp,
+            gpu_post_processing=gpu_post,
+            image_size=image_size,
+            tiled_inference=tiled_inference,
         )
     else:
         settings = _prompt_inference_settings(
@@ -347,6 +386,8 @@ def run_inference_cmd(
             default_refiner=refiner,
             default_comp=generate_comp,
             default_gpu_post=gpu_post,
+            default_image_size=image_size,
+            default_tiled_inference=tiled_inference,
         )
 
     with ProgressContext() as ctx_progress:


### PR DESCRIPTION
## What does this change?
* Added `--img_size` CLI argument (in wizard cli you can choose between 512-1024-2048 for user convenience).
* Added `--mlx_tiled_inference` CLI toggle to enable/disable tiled processing dynamically (defaults to the internal constant if not provided).
* Updated `create_engine` initialization to properly handle these dynamically passed arguments.
* MLX tiled inference is set to default False. Because it is approximately x5-x8 times faster when tiled inference disabled.

## How was it tested?
Tested on  both windows and mac with wizard cli. All checks run and passed.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
