### PR TITLE
Security: Remote code execution risk via `trust_remote_code=True` on downloaded model

### DIFF
--- a/BiRefNetModule/wrapper.py
+++ b/BiRefNetModule/wrapper.py
@@ -80,7 +80,7 @@ class BiRefNetHandler:
             local_dir_use_symlinks=False,  # Ensures actual files are downloaded, not just symlinks to the cache
         )
 
-        self.birefnet = AutoModelForImageSegmentation.from_pretrained(model_local_dir, trust_remote_code=True)
+        self.birefnet = AutoModelForImageSegmentation.from_pretrained(model_local_dir, trust_remote_code=False)
 
         self.birefnet.to(device)
         self.birefnet.eval()


### PR DESCRIPTION
## Problem

The code downloads model artifacts from Hugging Face and then loads them with `AutoModelForImageSegmentation.from_pretrained(..., trust_remote_code=True)`. When `trust_remote_code=True`, arbitrary Python code from the model repository can be executed during load. Because the download is not pinned to a specific immutable revision, upstream repository compromise or tampering could lead to code execution on client machines.

**Severity**: `critical`
**File**: `BiRefNetModule/wrapper.py`

## Solution

Set `trust_remote_code=False` whenever possible. If remote code is absolutely required, pin `snapshot_download` to a specific commit hash (`revision=`), verify checksums/signatures, and load only from vetted, immutable artifacts. Consider sandboxing model loading in a restricted process.

## Changes

- `BiRefNetModule/wrapper.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
