### PR TITLE
Security: Insecure deserialization via `torch.load` on LoRA checkpoint

### DIFF
--- a/gvm_core/gvm/pipelines/pipeline_gvm.py
+++ b/gvm_core/gvm/pipelines/pipeline_gvm.py
@@ -37,7 +37,10 @@ class GVMLoraLoader(StableDiffusionLoraLoaderMixin):
 
         unet_lora_config = LoraConfig.from_pretrained(pretrained_model_name_or_path_or_dict)
         checkpoint = os.path.join(pretrained_model_name_or_path_or_dict, f"pytorch_lora_weights.pt")
-        unet_lora_ckpt = torch.load(checkpoint)
+        load_kwargs = {"map_location": "cpu"}
+        if is_torch_version(">=", "2.0"):
+            load_kwargs["weights_only"] = True
+        unet_lora_ckpt = torch.load(checkpoint, **load_kwargs)
         self.unet = LoraModel(self.unet, unet_lora_config, "default")
         set_peft_model_state_dict(self.unet, unet_lora_ckpt)
 


### PR DESCRIPTION
## Problem

`torch.load(checkpoint)` is used to load a `.pt` file constructed from an external path. PyTorch checkpoint loading uses pickle semantics and can execute arbitrary code when loading malicious files. If an attacker can influence `pretrained_model_name_or_path_or_dict` or checkpoint contents, this can become code execution.

**Severity**: `high`
**File**: `gvm_core/gvm/pipelines/pipeline_gvm.py`

## Solution

Avoid pickle-based loading for untrusted files. Prefer `safetensors` for weights. If using PyTorch >=2.0+, use `torch.load(..., weights_only=True)` where compatible, and strictly validate/allowlist checkpoint locations.

## Changes

- `gvm_core/gvm/pipelines/pipeline_gvm.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
