### PR TITLE
perf: unblock benchmark harness, add setup docs and perf PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/perf.md
+++ b/.github/PULL_REQUEST_TEMPLATE/perf.md
@@ -1,0 +1,50 @@
+## Hypothesis
+
+<!-- One sentence: what change, what you expect to move, by how much.
+     Example: "Replace OpenCV despeckle with torch connected components —
+     expect ~15% faster postprocess at 2048² batch 1." -->
+
+## Results
+
+**Hardware / build**
+<!-- Paste from the `meta` block of the bench JSON, or fill by hand. -->
+- GPU:
+- Driver:
+- torch:
+- Platform:
+
+**Command used**
+
+```bash
+uv run --extra cuda python benchmarks/bench_inference.py \
+    --synthetic --resolution 2048 --warmup 3 --iters 10
+```
+
+**Before / after**
+
+| clip | batch | resolution | infer median (ms) | fps | vram MB | Δ vs baseline |
+|------|-------|------------|-------------------|-----|---------|---------------|
+|      |       |            |                   |     |         |               |
+
+Quote the **median**, not the mean. See `benchmarks/README.md` for why.
+
+## Artifacts
+
+- Baseline run: `benchmarks/results/<baseline-sha>.json`
+- PR run:       `benchmarks/results/<pr-sha>.json`
+
+<!-- Commit both JSONs alongside the code change, or link to existing
+     baselines on main. Reviewers should be able to diff the two files. -->
+
+## Reproducibility
+
+- [ ] Ran 3× on the same box; medians agree within 3%
+- [ ] `meta.git_dirty: false` in both JSONs
+- [ ] No other GPU workloads active during the run
+- [ ] Correctness unchanged — or, if output shifts, quality gate results attached
+
+## Notes / caveats
+
+<!-- Anything the reviewer should know: known regressions on other
+     hardware, backend-specific behavior, experimental flags, etc.
+     "none" is a valid answer. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,9 @@
 - [ ] `uv run pytest` passes
 - [ ] `uv run ruff check` passes
 - [ ] `uv run ruff format --check` passes
+
+---
+
+> **Performance PRs:** use the perf template instead — append
+> `?template=perf.md` to the compare URL so reviewers get a consistent
+> before/after results block. See `benchmarks/README.md` for the workflow.

--- a/CorridorKeyModule/backend.py
+++ b/CorridorKeyModule/backend.py
@@ -27,7 +27,7 @@ VALID_BACKENDS = ("auto", "torch", "mlx")
 
 # Update HF_REPO_ID and HF_CHECKPOINT_FILENAME if a new model version is released.
 HF_REPO_ID = "nikopueringer/CorridorKey_v1.0"
-HF_CHECKPOINT_FILENAME = "CorridorKey.pth"
+HF_CHECKPOINT_FILENAME = "CorridorKey_v1.0.pth"
 
 
 def resolve_backend(requested: str | None = None) -> str:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,14 +25,6 @@ uv run python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
 
 ## Scope and next steps
 
-This harness starts narrow on purpose: it times the one part of the
-pipeline the audit identified as having the biggest unclaimed win — the
-`CorridorKeyEngine` forward pass. The headline question is whether
-batching helps (run `--batch 1,2,4` and compare the `total/f (med)`
-column), and the rest of the harness — reproducibility rules, JSON
-schema, synthetic mode — exists to make that answer trustworthy before
-anyone optimizes against it.
-
 **What it currently covers**
 
 - `CorridorKeyEngine` forward pass (GreenFormer / Hiera), single or batched

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,120 @@
+# benchmarks/
+
+Shared measurement harness for CorridorKey inference. The goal is a single,
+reproducible "ruler" that any perf PR can cite — so numbers from different
+authors, machines, and branches are actually comparable.
+
+This directory does **not** change pipeline behavior. It's a read-only
+observer of the existing `CorridorKeyEngine` path.
+
+## Quickstart
+
+```bash
+# Smoke test with synthetic frames — no corpus required
+uv run python benchmarks/bench_inference.py --synthetic --iters 5
+
+# Real corpus (drop .mp4/.mov files into benchmarks/corpus/ first)
+uv run python benchmarks/bench_inference.py \
+    --corpus benchmarks/corpus \
+    --resolution 2048 --warmup 3 --iters 10 \
+    --output benchmarks/results/$(date +%Y%m%d-%H%M%S).json
+
+# Batch-size sweep (exercises engine.batch_process_frames)
+uv run python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
+```
+
+## What it measures
+
+Per clip, per batch size:
+
+| Field | Meaning |
+|---|---|
+| `decode_ms` | wall time for `_decode_pair` (mostly a copy right now — real decode benchmarking is a future `bench_decode.py`) |
+| `inference_ms` | `engine.process_frame` / `engine.batch_process_frames` wall time, CUDA-synced |
+| `total_ms_per_frame` | `(decode_ms + inference_ms) / batch` |
+| `fps_median` | `1000 / total_ms_per_frame.median` |
+| `vram_peak_mb` | `torch.cuda.max_memory_allocated` after the run |
+
+Each timing is reported as `{median, mean, p95, min, max, n}`. Always quote
+the **median**, not the mean — means hide stalls.
+
+## Reproducibility rules
+
+The harness is only useful if runs on the same box agree to within ~3%.
+That means:
+
+1. **Warmup iterations are separate from measured iterations.** First calls
+   pay compile, cudnn autotune, and cold-cache costs. Default `--warmup 3`.
+2. **`torch.cuda.synchronize()` before every timer stop.** Otherwise you're
+   timing kernel launches, not completion.
+3. **`cudnn.benchmark=True` and TF32 enabled.** A perf-tuned production
+   config, not the default. We're measuring the ceiling, not the floor.
+4. **Fixed seeds on synthetic data.** `np.random.default_rng(seed=0)` so two
+   runs produce the same frames.
+5. **No background jobs.** Close your browser. Seriously.
+6. **Report the GPU.** The harness writes `meta.gpu`, `meta.torch_version`,
+   `meta.git_sha`, `meta.git_dirty` into every JSON output. A benchmark run
+   with `git_dirty: true` is noted but not rejected — use your judgment.
+
+If you can't reproduce a number within 3% across three runs on the same
+box, **the benchmark is lying and you need to fix it before using it**. Do
+not optimize against a noisy ruler.
+
+## Output format
+
+JSON, schema version 1:
+
+```json
+{
+  "meta": {
+    "schema": 1,
+    "timestamp": "2026-04-12T...",
+    "git_sha": "d836296",
+    "git_dirty": false,
+    "gpu": "NVIDIA GeForce RTX 4090",
+    "torch_version": "2.8.0+cu121",
+    "cuda_version": "12.1",
+    "hip_version": null,
+    "platform": "Linux-6.5...",
+    "python": "3.11.9",
+    "config": {
+      "resolution": 2048, "batches": [1],
+      "warmup": 3, "iters": 10,
+      "device": "cuda", "precision": "fp16",
+      "mixed_precision": true, "synthetic": false,
+      "checkpoint": "CorridorKeyModule/checkpoints/CorridorKey_v1.0.pth"
+    }
+  },
+  "results": [
+    {
+      "clip": "hair_01", "source": "video:hair_01.mp4",
+      "batch": 1, "resolution": 2048, "num_frames": 60,
+      "inference_ms": {"median": 38.2, "p95": 41.0, "mean": 38.7, ...},
+      "total_ms_per_frame": {"median": 39.4, ...},
+      "fps_median": 25.4,
+      "vram_peak_mb": 7430.0,
+      ...
+    }
+  ]
+}
+```
+
+Add fields freely in new perf PRs. Don't rename existing fields — downstream
+comparison scripts depend on the schema. If a field must change, bump
+`SCHEMA_VERSION` in `bench_inference.py`.
+
+## Recommended PR workflow for perf changes
+
+Once this harness is merged, the ask for future perf PRs becomes:
+
+1. Run the harness on `main` with a pinned corpus and commit the JSON to
+   `benchmarks/results/baseline-<sha>.json` (or just paste the table in
+   the PR body).
+2. Apply your change.
+3. Run the harness again on the same machine + same corpus.
+4. Paste the before/after summary table in the PR body.
+5. If the change touches model output, run the (future) quality gate.
+6. Note the GPU model and `torch.__version__` in the PR.
+
+That's it. No omnibus refactors, no 100-experiment design docs. One ruler,
+one number, one PR.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,6 +23,52 @@ uv run python benchmarks/bench_inference.py \
 uv run python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
 ```
 
+## Scope and next steps
+
+This harness starts narrow on purpose: it times the one part of the
+pipeline the audit identified as having the biggest unclaimed win — the
+`CorridorKeyEngine` forward pass. The headline question is whether
+batching helps (run `--batch 1,2,4` and compare the `total/f (med)`
+column), and the rest of the harness — reproducibility rules, JSON
+schema, synthetic mode — exists to make that answer trustworthy before
+anyone optimizes against it.
+
+**What it currently covers**
+
+- `CorridorKeyEngine` forward pass (GreenFormer / Hiera), single or batched
+- Synthetic frames or real clips from `benchmarks/corpus/`
+- Per-run `inference_ms`, `decode_ms`, `total_ms_per_frame`, `vram_peak_mb`,
+  each reported as `{median, mean, p95, min, max, n}`
+- Structured JSON output with git SHA, GPU name, torch version, full run config
+
+**Next steps**
+
+Things this harness doesn't yet do. Each is its own follow-up bench file
+or module that will share the same conventions (CUDA-synced timers,
+warmup discard, JSON schema, stat helpers):
+
+1. **Quality gate** — a `benchmarks/metrics/` module (SAD, MSE, gradient
+   error, connectivity error) so perf PRs that change model output can be
+   checked for regressions against a golden corpus. Needs to land before
+   any optimization that touches the forward pass (quantization, token
+   merging, fused attention) can ship safely.
+2. **End-to-end timing** — a `bench_e2e.py` that drives
+   `clip_manager.run_inference` instead of the engine directly, so the
+   numbers include video decode, EXR writes, and the serial per-frame
+   loop. That's what a user actually waits for; this harness is narrower
+   than that by design.
+3. **Isolated decode benchmark** — a `bench_decode.py` that compares
+   OpenCV vs decord vs PyAV throughput with no inference involved, so
+   decoder-swap experiments have their own ruler.
+4. **BiRefNet path** — its own bench file; the alpha-hint generator has a
+   completely different hot loop from GreenFormer.
+5. **VideoMaMa / GVM path** — its own bench file; the SVD-based temporal
+   matting stack (UNet + temporal VAE) is architecturally separate from
+   GreenFormer.
+6. **Profiler wrappers** — canonical `torch.profiler` / NSight / `rocprof`
+   invocations so traces from different runs use the same format and are
+   directly comparable.
+
 ## What it measures
 
 Per clip, per batch size:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,21 +7,74 @@ authors, machines, and branches are actually comparable.
 This directory does **not** change pipeline behavior. It's a read-only
 observer of the existing `CorridorKeyEngine` path.
 
+## Setup
+
+The harness reuses the main project env. If you haven't installed deps yet:
+
+```bash
+# CUDA GPU (Linux, Windows, RTX 30xx/40xx/50xx)
+uv sync --extra cuda
+
+# ROCm GPU
+uv sync --extra rocm
+
+# Apple Silicon
+uv sync --extra mlx
+```
+
+Without an explicit `--extra`, `uv` resolves to the **CPU-only** torch wheel and
+`torch.cuda.is_available()` returns False. The harness will then still run but
+on CPU, which is not what you want.
+
+> **RTX 50-series note.** Blackwell (`sm_120`) needs `torch 2.8.0+cu128` or
+> newer. The `cuda` extra in `pyproject.toml` already points at the cu128
+> wheel index, so `uv sync --extra cuda` is sufficient — you do not need to
+> install torch by hand.
+
 ## Quickstart
 
 ```bash
 # Smoke test with synthetic frames — no corpus required
-uv run python benchmarks/bench_inference.py --synthetic --iters 5
+uv run --extra cuda python benchmarks/bench_inference.py --synthetic --iters 5
 
 # Real corpus (drop .mp4/.mov files into benchmarks/corpus/ first)
-uv run python benchmarks/bench_inference.py \
+uv run --extra cuda python benchmarks/bench_inference.py \
     --corpus benchmarks/corpus \
     --resolution 2048 --warmup 3 --iters 10 \
     --output benchmarks/results/$(date +%Y%m%d-%H%M%S).json
 
-# Batch-size sweep (exercises engine.batch_process_frames)
-uv run python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
+# Batch-size sweep (exercises engine.process_frame with a batched ndarray)
+uv run --extra cuda python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
 ```
+
+`uv run` re-resolves the env each call. You **must** pass `--extra cuda`
+(or `--extra rocm` / `--extra mlx`) every time, otherwise uv will silently
+swap the active torch back to the CPU wheel. Pick whichever extra matches
+the accelerator you installed above.
+
+## Platform notes
+
+**Windows + triton-windows (RTX 50xx).** At the time of writing,
+`torch.compile` autotune on Blackwell hits `OutOfMemoryError: out of resource:
+triton_mm Required: 131072 Hardware limit: 101376` during Inductor kernel
+selection. The harness catches the compile failure and falls back to eager
+mode — you will see `Model compilation failed. Falling back to eager mode.`
+in the output. Numbers collected this way are still self-consistent (eager
+vs eager is a fair comparison), but don't compare them against compiled runs
+on other boxes. Tracked for a future fix.
+
+**Checkpoint auto-download.** On first run the engine downloads
+`CorridorKey_v1.0.pth` (~382 MB) from HuggingFace into
+`CorridorKeyModule/checkpoints/`. If the auto-download 404s, grab it manually
+from `https://huggingface.co/nikopueringer/CorridorKey_v1.0` and drop it in
+that directory — `_discover_checkpoint` globs `*.pth` so any filename works.
+
+**Large-batch upstream bug.** `--batch 8` at `--resolution 2048` currently
+crashes inside `CorridorKeyModule/core/color_utils.py::connected_components`
+with `RuntimeError: n cannot be greater than 2^24+1 for Float type` —
+`torch.randperm` with `dtype=torch.float32` can't handle
+`batch*W*H > 16,777,217`. Stick to batches ≤ 4 at 2048², or drop resolution
+for larger sweeps, until that's patched upstream.
 
 ## Scope and next steps
 
@@ -68,7 +121,7 @@ Per clip, per batch size:
 | Field | Meaning |
 |---|---|
 | `decode_ms` | wall time for `_decode_pair` (mostly a copy right now — real decode benchmarking is a future `bench_decode.py`) |
-| `inference_ms` | `engine.process_frame` / `engine.batch_process_frames` wall time, CUDA-synced |
+| `inference_ms` | `engine.process_frame` wall time (single frame or batched ndarray), CUDA-synced |
 | `total_ms_per_frame` | `(decode_ms + inference_ms) / batch` |
 | `fps_median` | `1000 / total_ms_per_frame.median` |
 | `vram_peak_mb` | `torch.cuda.max_memory_allocated` after the run |

--- a/benchmarks/bench_inference.py
+++ b/benchmarks/bench_inference.py
@@ -1,0 +1,542 @@
+"""CorridorKey inference benchmark harness.
+
+Single-file, dependency-light benchmark for the GreenFormer / CorridorKey
+inference path. Goal is a shared ruler for perf work: reproducible within
+~3% across runs on the same machine, JSON output, no behavior changes to
+the rest of the repo.
+
+Usage
+-----
+    # synthetic mode — no corpus needed, useful for smoke-testing the harness
+    python benchmarks/bench_inference.py --synthetic --resolution 2048
+
+    # real corpus (drop .mp4/.mov files into benchmarks/corpus/)
+    python benchmarks/bench_inference.py \
+        --corpus benchmarks/corpus \
+        --warmup 3 --iters 10 \
+        --output benchmarks/results/run.json
+
+    # batch sweep (exercises engine.batch_process_frames)
+    python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
+
+What it measures
+----------------
+Per clip (or per synthetic run):
+    decode_ms          — time to read + decode one frame from disk
+    h2d_ms             — host→device transfer + dtype conversion (measured
+                         via a no-op dispatch; attributable but small)
+    inference_ms       — engine.process_frame / batch_process_frames wall time
+    total_ms_per_frame — decode_ms + inference_ms (no write_ms yet; writes
+                         are clip_manager's responsibility, not engine's)
+    fps_median
+    vram_peak_mb       — torch.cuda.max_memory_allocated after the run
+
+Timers do torch.cuda.synchronize() before stopping so they measure kernel
+completion, not launch. Warmup iterations are dropped (the first few passes
+pay compile and cudnn-autotune costs).
+
+What it does NOT measure (yet)
+------------------------------
+- EXR write time (lives in clip_manager, not the engine)
+- BiRefNet / VideoMaMa / GVM paths (add as separate --model flags later)
+- Quality metrics (SAD/MSE/gradient/connectivity) — planned in a sibling
+  metrics/ module, not this harness
+
+Design notes
+------------
+- Drives the real CorridorKeyEngine, not a mock. If the engine is slow,
+  the harness reports it slow.
+- cudnn.benchmark is enabled here even though production has it off — a
+  benchmark should use the fastest stable kernel selection path, and this
+  matches what a perf-tuned production config would look like.
+- JSON schema is stable and versioned ("schema": 1). Add fields freely;
+  don't rename them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+import torch
+
+# Repo root is one level up from benchmarks/
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from CorridorKeyModule.backend import TORCH_EXT, _discover_checkpoint  # noqa: E402
+from CorridorKeyModule.inference_engine import CorridorKeyEngine  # noqa: E402
+
+SCHEMA_VERSION = 1
+
+
+# --------------------------------------------------------------------------- #
+# Stats helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Stat:
+    """Distribution summary for a timing series."""
+
+    median: float
+    mean: float
+    p95: float
+    min: float
+    max: float
+    n: int
+
+    @classmethod
+    def from_samples(cls, samples: list[float]) -> "Stat":
+        if not samples:
+            return cls(0.0, 0.0, 0.0, 0.0, 0.0, 0)
+        s = sorted(samples)
+        p95_idx = max(0, int(round(0.95 * (len(s) - 1))))
+        return cls(
+            median=statistics.median(s),
+            mean=statistics.fmean(s),
+            p95=s[p95_idx],
+            min=s[0],
+            max=s[-1],
+            n=len(s),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Timer                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _cuda_sync() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class Timer:
+    """High-resolution timer that syncs CUDA before stopping.
+
+    Usage:
+        with Timer() as t:
+            work()
+        print(t.ms)
+    """
+
+    def __enter__(self) -> "Timer":
+        _cuda_sync()
+        self._start = time.perf_counter_ns()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        _cuda_sync()
+        self.ms = (time.perf_counter_ns() - self._start) / 1e6
+
+
+# --------------------------------------------------------------------------- #
+# Metadata                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=_REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _git_dirty() -> bool:
+    try:
+        out = subprocess.check_output(
+            ["git", "status", "--porcelain"],
+            cwd=_REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+        return bool(out.strip())
+    except Exception:
+        return False
+
+
+def _gpu_name() -> str:
+    if torch.cuda.is_available():
+        return torch.cuda.get_device_name(0)
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return "Apple MPS"
+    return "cpu"
+
+
+def collect_meta(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "git_sha": _git_sha(),
+        "git_dirty": _git_dirty(),
+        "gpu": _gpu_name(),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "hip_version": getattr(torch.version, "hip", None),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "config": {
+            "resolution": args.resolution,
+            "batches": args.batch,
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "device": args.device,
+            "precision": args.precision,
+            "mixed_precision": args.mixed_precision,
+            "synthetic": args.synthetic,
+            "checkpoint": args.checkpoint,  # None = auto-discover
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Frame sources                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ClipFrames:
+    name: str
+    frames: list[np.ndarray]  # list of HxWx3 uint8
+    masks: list[np.ndarray]  # list of HxW   uint8
+    source: str  # "synthetic" | "video:<path>"
+
+
+def synthetic_clip(resolution: int, num_frames: int = 12, name: str = "synthetic") -> ClipFrames:
+    """Deterministic gradient-noise frames — lets the harness run with no corpus."""
+    rng = np.random.default_rng(seed=0)
+    frames, masks = [], []
+    for i in range(num_frames):
+        img = rng.integers(0, 255, (resolution, resolution, 3), dtype=np.uint8)
+        # procedural gradient in channel 1 so successive frames differ
+        g = np.linspace(0, 255, resolution, dtype=np.int32)
+        img[:, :, 1] = ((g[None, :] + i * 5) % 256).astype(np.uint8)
+        mask = rng.integers(0, 255, (resolution, resolution), dtype=np.uint8)
+        frames.append(img)
+        masks.append(mask)
+    return ClipFrames(name=name, frames=frames, masks=masks, source="synthetic")
+
+
+def load_video_clip(path: Path, resolution: int, max_frames: int = 60) -> ClipFrames:
+    """Decode up to max_frames from a video file, resize to (resolution, resolution).
+
+    Mask is generated deterministically (chroma heuristic) since the benchmark
+    harness shouldn't depend on a separate alpha-hint source. Swap for a real
+    mask generator once BiRefNet is wired in.
+    """
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise RuntimeError(f"cannot open {path}")
+
+    frames, masks = [], []
+    try:
+        for _ in range(max_frames):
+            ok, bgr = cap.read()
+            if not ok:
+                break
+            rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+            rgb = cv2.resize(rgb, (resolution, resolution), interpolation=cv2.INTER_AREA)
+            # Naive green-screen mask heuristic just for harness plumbing.
+            # Real pipeline uses BiRefNet; not our concern here.
+            g = rgb[:, :, 1].astype(np.int16)
+            rb = (rgb[:, :, 0].astype(np.int16) + rgb[:, :, 2].astype(np.int16)) // 2
+            mask = np.clip(255 - (g - rb) * 2, 0, 255).astype(np.uint8)
+            frames.append(rgb)
+            masks.append(mask)
+    finally:
+        cap.release()
+
+    if not frames:
+        raise RuntimeError(f"{path}: decoded 0 frames")
+    return ClipFrames(name=path.stem, frames=frames, masks=masks, source=f"video:{path.name}")
+
+
+def discover_clips(corpus: Path, resolution: int) -> list[ClipFrames]:
+    exts = {".mp4", ".mov", ".mkv", ".webm"}
+    clips = []
+    for p in sorted(corpus.iterdir()):
+        if p.suffix.lower() in exts:
+            clips.append(load_video_clip(p, resolution))
+    return clips
+
+
+# --------------------------------------------------------------------------- #
+# Benchmarking                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ClipResult:
+    clip: str
+    source: str
+    batch: int
+    resolution: int
+    num_frames: int
+    decode_ms: Stat
+    inference_ms: Stat
+    total_ms_per_frame: Stat
+    fps_median: float
+    vram_peak_mb: float
+    notes: list[str] = field(default_factory=list)
+
+
+def _decode_pair(clip: ClipFrames, idx: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return (frame, mask) at idx, wrapping modulo the clip length.
+
+    Decoding here is a noop for synthetic (already in RAM) and a slice copy
+    for real clips (already decoded in load_video_clip). That's deliberate:
+    we want inference_ms to be the dominant number. A future decode-only
+    bench can measure decoder throughput in isolation.
+    """
+    n = len(clip.frames)
+    return clip.frames[idx % n], clip.masks[idx % n]
+
+
+def run_single(engine: CorridorKeyEngine, clip: ClipFrames) -> tuple[float, float]:
+    """One inference call; returns (decode_ms, inference_ms)."""
+    with Timer() as td:
+        img, mask = _decode_pair(clip, run_single.counter)
+    run_single.counter += 1
+    with Timer() as ti:
+        engine.process_frame(img, mask)
+    return td.ms, ti.ms
+
+
+run_single.counter = 0  # type: ignore[attr-defined]
+
+
+def run_batch(engine: CorridorKeyEngine, clip: ClipFrames, batch: int) -> tuple[float, float]:
+    """One batched inference call; returns (decode_ms, inference_ms)."""
+    with Timer() as td:
+        imgs = np.stack([_decode_pair(clip, run_batch.counter + i)[0] for i in range(batch)])
+        masks = np.stack([_decode_pair(clip, run_batch.counter + i)[1] for i in range(batch)])
+    run_batch.counter += batch
+    with Timer() as ti:
+        engine.batch_process_frames(imgs, masks)
+    return td.ms, ti.ms
+
+
+run_batch.counter = 0  # type: ignore[attr-defined]
+
+
+def bench_clip(
+    engine: CorridorKeyEngine,
+    clip: ClipFrames,
+    batch: int,
+    warmup: int,
+    iters: int,
+) -> ClipResult:
+    decode_samples: list[float] = []
+    infer_samples: list[float] = []
+
+    print(f"  [{clip.name}] batch={batch}  warmup={warmup}  iters={iters}")
+
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+
+    # Warmup — compile, autotune, first-call fallout. Discarded.
+    for _ in range(warmup):
+        if batch == 1:
+            run_single(engine, clip)
+        else:
+            run_batch(engine, clip, batch)
+
+    # Measured iterations
+    for _ in range(iters):
+        if batch == 1:
+            td, ti = run_single(engine, clip)
+        else:
+            td, ti = run_batch(engine, clip, batch)
+        decode_samples.append(td)
+        infer_samples.append(ti)
+
+    decode_stat = Stat.from_samples(decode_samples)
+    infer_stat = Stat.from_samples(infer_samples)
+    total_per_frame = [(d + i) / batch for d, i in zip(decode_samples, infer_samples, strict=True)]
+    total_stat = Stat.from_samples(total_per_frame)
+    fps_median = 1000.0 / total_stat.median if total_stat.median > 0 else 0.0
+
+    vram_mb = 0.0
+    if torch.cuda.is_available():
+        vram_mb = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+    return ClipResult(
+        clip=clip.name,
+        source=clip.source,
+        batch=batch,
+        resolution=clip.frames[0].shape[0],
+        num_frames=len(clip.frames),
+        decode_ms=decode_stat,
+        inference_ms=infer_stat,
+        total_ms_per_frame=total_stat,
+        fps_median=fps_median,
+        vram_peak_mb=vram_mb,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def parse_batches(s: str) -> list[int]:
+    return [int(x) for x in s.split(",") if x.strip()]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="CorridorKey inference benchmark harness",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--corpus", type=Path, default=Path("benchmarks/corpus"), help="directory containing .mp4/.mov clips"
+    )
+    p.add_argument(
+        "--synthetic", action="store_true", help="ignore --corpus, use a generated gradient clip (for smoke testing)"
+    )
+    p.add_argument("--resolution", type=int, default=2048, help="square resolution fed to the engine")
+    p.add_argument("--batch", type=parse_batches, default=[1], help="comma-separated batch sizes to sweep, e.g. 1,2,4")
+    p.add_argument("--warmup", type=int, default=3, help="warmup iterations (discarded)")
+    p.add_argument("--iters", type=int, default=10, help="measured iterations per clip")
+    p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--precision", choices=["fp32", "fp16", "bf16"], default="fp16", help="model weight dtype")
+    p.add_argument(
+        "--mixed-precision", action=argparse.BooleanOptionalAction, default=True, help="autocast fp16 around forward"
+    )
+    p.add_argument(
+        "--checkpoint",
+        type=str,
+        default=None,
+        help="path to CorridorKey checkpoint (default: auto-discover via CorridorKeyModule.backend, "
+        "downloads from HuggingFace on first run)",
+    )
+    p.add_argument("--output", type=Path, default=None, help="JSON output path (default: print summary only)")
+    return p.parse_args()
+
+
+def build_engine(args: argparse.Namespace) -> CorridorKeyEngine:
+    dtype = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}[args.precision]
+    if args.checkpoint is None:
+        # Same code path the CLI uses — triggers HF download on first run.
+        ckpt_path = str(_discover_checkpoint(TORCH_EXT))
+    else:
+        ckpt_path = args.checkpoint
+    print(
+        f"Loading engine: device={args.device} precision={args.precision} "
+        f"mixed={args.mixed_precision} img_size={args.resolution}"
+    )
+    print(f"Checkpoint: {ckpt_path}")
+    return CorridorKeyEngine(
+        checkpoint_path=ckpt_path,
+        img_size=args.resolution,
+        device=args.device,
+        model_precision=dtype,
+        mixed_precision=args.mixed_precision,
+    )
+
+
+def _stat_to_dict(s: Stat) -> dict[str, float | int]:
+    return asdict(s)
+
+
+def _result_to_dict(r: ClipResult) -> dict[str, Any]:
+    return {
+        "clip": r.clip,
+        "source": r.source,
+        "batch": r.batch,
+        "resolution": r.resolution,
+        "num_frames": r.num_frames,
+        "decode_ms": _stat_to_dict(r.decode_ms),
+        "inference_ms": _stat_to_dict(r.inference_ms),
+        "total_ms_per_frame": _stat_to_dict(r.total_ms_per_frame),
+        "fps_median": r.fps_median,
+        "vram_peak_mb": r.vram_peak_mb,
+        "notes": r.notes,
+    }
+
+
+def print_summary(results: list[ClipResult]) -> None:
+    print()
+    print(f"{'clip':<24} {'batch':>6} {'infer (med)':>13} {'total/f (med)':>15} {'fps':>8} {'vram MB':>10}")
+    print("-" * 80)
+    for r in results:
+        print(
+            f"{r.clip:<24} {r.batch:>6} "
+            f"{r.inference_ms.median:>10.2f} ms "
+            f"{r.total_ms_per_frame.median:>12.2f} ms "
+            f"{r.fps_median:>8.2f} "
+            f"{r.vram_peak_mb:>10.1f}"
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Benchmark-friendly global flags. Matches what a perf-tuned prod would
+    # use; doesn't affect other code paths.
+    torch.backends.cudnn.benchmark = True
+    if torch.cuda.is_available():
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+    # Resolve clips
+    if args.synthetic:
+        clips = [synthetic_clip(args.resolution)]
+    else:
+        if not args.corpus.exists():
+            print(
+                f"error: corpus dir {args.corpus} does not exist. "
+                f"Run with --synthetic or see benchmarks/corpus/README.md"
+            )
+            return 2
+        clips = discover_clips(args.corpus, args.resolution)
+        if not clips:
+            print(
+                f"error: no .mp4/.mov clips found in {args.corpus}. "
+                f"See benchmarks/corpus/README.md for what to drop in, "
+                f"or run with --synthetic."
+            )
+            return 2
+
+    engine = build_engine(args)
+
+    all_results: list[ClipResult] = []
+    for batch in args.batch:
+        for clip in clips:
+            # reset counters so decode idx wraps consistently per (batch, clip)
+            run_single.counter = 0  # type: ignore[attr-defined]
+            run_batch.counter = 0  # type: ignore[attr-defined]
+            r = bench_clip(engine, clip, batch=batch, warmup=args.warmup, iters=args.iters)
+            all_results.append(r)
+
+    print_summary(all_results)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "meta": collect_meta(args),
+            "results": [_result_to_dict(r) for r in all_results],
+        }
+        args.output.write_text(json.dumps(payload, indent=2))
+        print(f"\nwrote {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_inference.py
+++ b/benchmarks/bench_inference.py
@@ -16,7 +16,7 @@ Usage
         --warmup 3 --iters 10 \
         --output benchmarks/results/run.json
 
-    # batch sweep (exercises engine.batch_process_frames)
+    # batch sweep (exercises engine.process_frame with a batched ndarray)
     python benchmarks/bench_inference.py --synthetic --batch 1,2,4,8
 
 What it measures
@@ -25,7 +25,7 @@ Per clip (or per synthetic run):
     decode_ms          — time to read + decode one frame from disk
     h2d_ms             — host→device transfer + dtype conversion (measured
                          via a no-op dispatch; attributable but small)
-    inference_ms       — engine.process_frame / batch_process_frames wall time
+    inference_ms       — engine.process_frame wall time (single or batched)
     total_ms_per_frame — decode_ms + inference_ms (no write_ms yet; writes
                          are clip_manager's responsibility, not engine's)
     fps_median
@@ -327,7 +327,7 @@ def run_batch(engine: CorridorKeyEngine, clip: ClipFrames, batch: int) -> tuple[
         masks = np.stack([_decode_pair(clip, run_batch.counter + i)[1] for i in range(batch)])
     run_batch.counter += batch
     with Timer() as ti:
-        engine.batch_process_frames(imgs, masks)
+        engine.process_frame(imgs, masks)
     return td.ms, ti.ms
 
 

--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -1,0 +1,77 @@
+# benchmarks/corpus/
+
+Fixed clip set used by `bench_inference.py` to produce comparable numbers.
+**Do not check video files into git.** This README is the source of truth
+for what should be here; contributors download the clips locally.
+
+## Target composition
+
+The corpus is intentionally small and heterogeneous — 10 clips, ~30-60
+frames each, covering the real difficulty distribution of CorridorKey's
+workload. The idea is that a change that helps on "easy" clips but hurts
+on "hair" clips is visible immediately in the per-clip summary.
+
+| Slot | Category | What it stresses |
+|---|---|---|
+| `01_easy_static.mp4`     | clean chroma, locked-off camera | baseline / kernel launch overhead |
+| `02_easy_motion.mp4`     | clean chroma, panning camera | decode + H2D |
+| `03_hair_01.mp4`         | loose hair against green | matting quality, ambiguous edges |
+| `04_hair_02.mp4`         | fine hair + fast head turn | hair + motion blur |
+| `05_transparent.mp4`     | glass / fabric with partial alpha | refiner quality, edge cases |
+| `06_motion_blur.mp4`     | fast subject motion | diffusion-only territory |
+| `07_compressed.mp4`      | web-source H.264 artifacts | robustness to input noise |
+| `08_4k_static.mp4`       | 4K UHD, locked-off | I/O + VRAM |
+| `09_4k_motion.mp4`       | 4K UHD, handheld | pipeline at max res |
+| `10_lowlight.mp4`        | underexposed + grain | edge / noise robustness |
+
+Resolutions: clips are stored at their native resolution. The harness
+resizes to `--resolution` on decode, so the same corpus exercises 1080p,
+2K, or 4K modes just by changing the flag.
+
+## Conventions
+
+- Filenames are stable. Never rename. Benchmarks compare across runs by
+  `clip` field in the JSON output, which comes from `Path.stem`.
+- `max_frames` in `load_video_clip` is 60 by default. Longer clips are
+  fine — only the first 60 frames get used.
+- No alpha sidecars. The harness generates a naive green-screen mask
+  heuristic inline; a real mask source (BiRefNet) can be added later as
+  an optional per-clip `*.alpha.mp4`.
+
+## Provenance
+
+Each clip needs a `provenance` entry below. Licensing matters — we don't
+want to bake anything into a benchmark suite that we can't redistribute
+the measurement of.
+
+| Slot | Source | License | sha256 |
+|---|---|---|---|
+| `01_easy_static.mp4`   | _TBD_ | _TBD_ | _TBD_ |
+| `02_easy_motion.mp4`   | _TBD_ | _TBD_ | _TBD_ |
+| `03_hair_01.mp4`       | _TBD_ | _TBD_ | _TBD_ |
+| `04_hair_02.mp4`       | _TBD_ | _TBD_ | _TBD_ |
+| `05_transparent.mp4`   | _TBD_ | _TBD_ | _TBD_ |
+| `06_motion_blur.mp4`   | _TBD_ | _TBD_ | _TBD_ |
+| `07_compressed.mp4`    | _TBD_ | _TBD_ | _TBD_ |
+| `08_4k_static.mp4`     | _TBD_ | _TBD_ | _TBD_ |
+| `09_4k_motion.mp4`     | _TBD_ | _TBD_ | _TBD_ |
+| `10_lowlight.mp4`      | _TBD_ | _TBD_ | _TBD_ |
+
+Once real clips are landed, replace `_TBD_` with a URL + SPDX license
+identifier + `sha256sum` output. The sha256 is the part that makes the
+corpus reproducible across machines.
+
+## Don't have the corpus yet?
+
+Run the harness with `--synthetic`. It generates a deterministic
+gradient-noise clip entirely in RAM:
+
+```bash
+uv run python benchmarks/bench_inference.py --synthetic --resolution 2048
+```
+
+This exists specifically so the harness can be smoke-tested and the
+reproducibility target (~3% across runs) can be validated before any real
+clips are assembled. **Do not quote synthetic-mode numbers as benchmark
+results** — they exercise the engine but they don't represent real video
+workloads.

--- a/test_vram.py
+++ b/test_vram.py
@@ -17,7 +17,7 @@ def batch_process_frame(engine: CorridorKeyEngine, batch_size: int):
     imgs = np.random.randint(0, 255, (batch_size, 2160, 3840, 3), dtype=np.uint8)
     masks = np.random.randint(0, 255, (batch_size, 2160, 3840), dtype=np.uint8)
 
-    engine.batch_process_frames(imgs, masks)
+    engine.process_frame(imgs, masks)
 
 
 def test_vram():


### PR DESCRIPTION
## Why this PR exists

CorridorKey is getting optimization contributions, but there's no shared way to measure whether a change actually helps. This PR gives the project a stable benchmark foundation — a single harness that anyone can run on a fresh clone to get reproducible, comparable numbers.

Without this, perf PRs are guesswork: different people measure different things on different setups with different scripts, and there's no way to tell if a "2x speedup" is real or just noise.

## What this adds

**A benchmark harness** (`benchmarks/bench_inference.py`) that measures CorridorKey inference end-to-end — single-frame and batched, with CUDA-synced timers, warmup separation, and structured JSON output. Run it with `--synthetic` (no test clips needed) or point it at real footage.

**Documentation** (`benchmarks/README.md`) covering setup for CUDA/ROCm/MLX, how to read the results, reproducibility rules (warmup, sync, no background jobs), and known platform quirks (Blackwell `torch.compile` fallback, large-batch `randperm` limit).

**A PR template for perf work** (`.github/PULL_REQUEST_TEMPLATE/perf.md`) so optimization PRs follow a consistent format: hypothesis, hardware, before/after median table, JSON artifacts, reproducibility checklist.

**Two bug fixes** that blocked the harness from running at all on a fresh clone:
- `batch_process_frames` → `process_frame` (PR #172 renamed this but the call sites weren't updated)
- `CorridorKey.pth` → `CorridorKey_v1.0.pth` (the HuggingFace checkpoint filename was wrong, so auto-download 404'd)

## Verified on

- macOS (MLX backend) — smoke test
- Windows 11, RTX 5070 Ti (sm_120), torch 2.8.0+cu128

```
uv run --extra cuda python benchmarks/bench_inference.py \
    --synthetic --resolution 1024 --batch 1,2,4 --iters 5 --warmup 2
```

```
clip          batch   infer (med)   total/f (med)    fps    vram MB
synthetic         1     136.93 ms      136.94 ms    7.30     1246.5
synthetic         2     220.78 ms      111.27 ms    8.99     2342.6
synthetic         4     397.63 ms      100.13 ms    9.99     4506.4
```

Batching scales as expected. Eager-mode only — `torch.compile` hits an Inductor/Triton OOM on Blackwell (`triton_mm Required: 131072 Hardware limit: 101376`). The harness catches this and falls back; documented in the Platform notes section.