### PR TITLE
Add test matrix to cover different configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,16 @@ jobs:
         run: uv run ruff check
 
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.13"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.11"
+    runs-on: ${{matrix.os}}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.11", "3.13"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,6 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -v --tb=short -m "not gpu"
+
+      - name: Smoke Test
+        run: uv run corridorkey --help


### PR DESCRIPTION
## What does this change?
This expands the CI test matrix to run tests across Python 3.10–3.13 on Ubuntu, and adds macOS and Windows runners with Python 3.11 for cross-platform coverage. A corridorkey --help smoke test is included to validate the CLI entry point on all platforms.

## How was it tested?
I Forked the repository and then pushed changes.  Was able to see the actions run successfully on the fork.  Here is the [link](https://github.com/ZacharyRSaunders/CorridorKey/actions)
## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
