### PR TITLE
Fix GPU fallback to ignore empty probe results

### DIFF
--- a/device_utils.py
+++ b/device_utils.py
@@ -243,11 +243,11 @@ def enumerate_gpus() -> list[GPUInfo]:
     Returns an empty list on non-GPU systems.
     """
     gpus = _enumerate_nvidia()
-    if gpus is not None:
+    if gpus:
         return gpus
 
     gpus = _enumerate_amd()
-    if gpus is not None:
+    if gpus:
         return gpus
 
     # Fallback to torch (works for both NVIDIA and ROCm via HIP)


### PR DESCRIPTION
## What does this change?

Updates enumerate_gpus() in [device_utils.py](app://-/index.html?hostId=local) so fallback continues when a probe returns an empty list:

if gpus is not None: -> if gpus:
Applied to both NVIDIA and AMD checks.
This means only a non-empty GPU list returns early; [] now falls through to the next fallback step.

## How was it tested?

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
