### PR TITLE
fix(tests): set OPENCV_IO_ENABLE_OPENEXR in conftest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ markers = [
     "slow: long-running test",
     "mlx: requires Apple Silicon with MLX installed",
 ]
-env = ["OPENCV_IO_ENABLE_OPENEXR=1", ]
 addopts = "--tb=short"
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest configuration and fixtures for CorridorKey tests."""
 
+import os
 import platform
 import sys
 from types import ModuleType
@@ -8,6 +9,9 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import torch
+
+# OpenCV reads OPENCV_IO_ENABLE_OPENEXR at import time; set it before any test imports cv2.
+os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
 
 
 def _has_gpu():


### PR DESCRIPTION
## What does this change?

`pyproject.toml` sets `env = ["OPENCV_IO_ENABLE_OPENEXR=1"]` under
`[tool.pytest.ini_options]`, but that option requires the `pytest-env`
plugin, which is not in the dev dependency group. Pytest emits
`PytestConfigWarning: Unknown config option: env` on every run and the
env var is never actually exported by the config declaration.

This PR replaces the inert config line with
`os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")` at the top of
`tests/conftest.py` (after imports). OpenCV reads the flag at import
time, and `conftest.py` only imports `cv2` inside two fixtures, so the
`setdefault` runs before any test module brings `cv2` in. `setdefault`
preserves the existing workflow-level export in
`.github/workflows/ci.yml`. No new dependencies are added.

## How was it tested?

Locally on Windows with Python 3.13.11 (`uv sync --group dev`), with
`OPENCV_IO_ENABLE_OPENEXR` explicitly `unset` in the shell so the
conftest fix has to stand on its own:

- `uv run ruff format --check`: 43 files clean
- `uv run ruff check`: all checks passed
- `uv run pytest -v --tb=short -m "not gpu"`: 363 passed, 1 skipped
  (MLX), 4 deselected (GPU), 1 warning. The `Unknown config option: env`
  warning is gone; the remaining warning is an unrelated torch autocast
  note on a no-CUDA machine.
- `uv run corridorkey --help`: exits 0

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
