### PR TITLE
fix(cli): default unset optional flags to InferenceSettings values

### DIFF
--- a/corridorkey_cli.py
+++ b/corridorkey_cli.py
@@ -372,10 +372,10 @@ def run_inference_cmd(
             auto_despeckle=despeckle,
             despeckle_size=despeckle_size if despeckle_size is not None else 400,
             refiner_scale=refiner,
-            generate_comp=generate_comp,
-            gpu_post_processing=gpu_post,
-            image_size=image_size,
-            tiled_inference=tiled_inference,
+            generate_comp=generate_comp if generate_comp is not None else InferenceSettings.generate_comp,
+            gpu_post_processing=gpu_post if gpu_post is not None else InferenceSettings.gpu_post_processing,
+            image_size=image_size if image_size is not None else InferenceSettings.image_size,
+            tiled_inference=tiled_inference if tiled_inference is not None else InferenceSettings.tiled_inference,
         )
     else:
         settings = _prompt_inference_settings(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,3 +255,39 @@ class TestNonInteractiveFlags:
         mock_run.assert_called_once()
         _, kwargs = mock_run.call_args
         assert kwargs["skip_existing"] is True
+
+    @patch("corridorkey_cli.scan_clips")
+    @patch("corridorkey_cli.run_inference")
+    def test_headless_optional_flags_use_dataclass_defaults(self, mock_run, mock_scan):
+        """Unset optional flags fall back to InferenceSettings defaults, not None.
+
+        When the four required flags (--linear/--srgb, --despill, --despeckle,
+        --refiner) are provided, the headless branch skips the interactive
+        prompt. Optional flags (--comp, --gpu-post, --image-size, --tile) left
+        unset must inherit the InferenceSettings dataclass defaults rather
+        than propagate as None, since downstream code uses these fields as
+        bool/int without None-guards.
+        """
+        mock_scan.return_value = []
+
+        result = runner.invoke(
+            app,
+            [
+                "run-inference",
+                "--srgb",
+                "--despill",
+                "5",
+                "--despeckle",
+                "--refiner",
+                "1.0",
+            ],
+        )
+        assert result.exit_code == 0
+
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        settings = kwargs["settings"]
+        assert settings.generate_comp is True
+        assert settings.gpu_post_processing is False
+        assert settings.image_size == 2048
+        assert settings.tiled_inference is False


### PR DESCRIPTION
## What does this change?

The headless branch of `run-inference`
(`corridorkey_cli.py:369-379`) constructs `InferenceSettings(...)`
directly when the four required flags (`--linear/--srgb`,
`--despill`, `--despeckle`, `--refiner`) are all provided. Four
optional flags (`--comp`, `--gpu-post`, `--image-size`, `--tile`)
were forwarded as-is, so a `None` from Typer's default flowed
straight into dataclass fields typed `bool` or `int`.

Running the new regression test against unfixed code confirmed the
resulting settings object as:

    InferenceSettings(..., generate_comp=None, gpu_post_processing=None,
        image_size=None, tiled_inference=None)

which silently breaks downstream code treating those fields as
`bool`/`int`. The interactive branch
(`_prompt_inference_settings`, lines 161-164) already handled this
by falling back to `InferenceSettings.<field>` when a default was
`None`.

This PR applies the same pattern to the headless branch and adds
`test_headless_optional_flags_use_dataclass_defaults` in the
existing `TestNonInteractiveFlags` class to prevent regression.

## How was it tested?

TDD: wrote the regression test first, observed it fail against the
bug on `upstream/main`, applied the fix, observed the test pass.
Then full-suite regression check.

- `uv run ruff format --check`: clean
- `uv run ruff check`: clean
- `uv run pytest -q --tb=short -m "not gpu"`: 364 passed, 1 skipped
  (MLX), 4 deselected (GPU). The +1 pass vs upstream's 363 is the
  new regression test.
- The two warnings in the suite output (`PytestConfigWarning:
  Unknown config option: env` and a torch autocast warning on a
  no-CUDA machine) are both pre-existing on `upstream/main` and not
  introduced by this change.
- `uv run corridorkey --help`: exits 0

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
