### PR TITLE
fix: correct HuggingFace checkpoint filenames in code and installers

### DIFF
--- a/CorridorKeyModule/backend.py
+++ b/CorridorKeyModule/backend.py
@@ -30,8 +30,8 @@ VALID_BACKENDS = ("auto", "torch", "mlx")
 
 # Update HF_REPO_ID and HF_CHECKPOINT_FILENAME_* if a new model version is released.
 HF_REPO_ID = "nikopueringer/CorridorKey_v1.0"
-HF_CHECKPOINT_FILENAME_SAFETENSORS = "CorridorKey.safetensors"
-HF_CHECKPOINT_FILENAME = "CorridorKey.pth"  # DEPRECATED: remove after .pth sunset
+HF_CHECKPOINT_FILENAME_SAFETENSORS = "CorridorKey_v1.0.safetensors"
+HF_CHECKPOINT_FILENAME = "CorridorKey_v1.0.pth"  # DEPRECATED: remove after .pth sunset
 
 
 def resolve_backend(requested: str | None = None) -> str:

--- a/Install_CorridorKey_Linux_Mac.sh
+++ b/Install_CorridorKey_Linux_Mac.sh
@@ -76,7 +76,7 @@ else
     echo "Downloading CorridorKey.safetensors..."
     # --fail returns non-zero on HTTP errors (e.g. 404 before the safetensors
     # upload lands); fall back to the legacy .pth in that case.
-    if ! curl -L --fail -o "$SAFETENSORS_PATH" "$HF_BASE/CorridorKey.safetensors"; then
+    if ! curl -L --fail -o "$SAFETENSORS_PATH" "$HF_BASE/CorridorKey_v1.0.safetensors"; then
         echo "safetensors not available yet — falling back to CorridorKey.pth..."
         rm -f "$SAFETENSORS_PATH"
         # DEPRECATED: remove after .pth sunset

--- a/Install_CorridorKey_Windows.bat
+++ b/Install_CorridorKey_Windows.bat
@@ -61,7 +61,7 @@ if exist "%SAFETENSORS_PATH%" (
     echo Downloading CorridorKey.safetensors...
     REM --fail returns non-zero on HTTP errors (e.g. 404 before the safetensors
     REM upload lands); fall back to the legacy .pth in that case.
-    curl.exe -L --fail -o "%SAFETENSORS_PATH%" "%HF_BASE%/CorridorKey.safetensors"
+    curl.exe -L --fail -o "%SAFETENSORS_PATH%" "%HF_BASE%/CorridorKey_v1.0.safetensors"
     if errorlevel 1 (
         echo safetensors not available yet -- falling back to CorridorKey.pth...
         if exist "%SAFETENSORS_PATH%" del "%SAFETENSORS_PATH%"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This project uses **[uv](https://docs.astral.sh/uv/)** to manage Python and all 
     ```
     For **AMD ROCm** setup, see the [AMD ROCm Setup](#amd-rocm-setup) section below.
 4.  **Download the Models:**
-    *   **CorridorKey v1.0 Model (~300MB):** Downloads automatically on first run. If no checkpoint is found in `CorridorKeyModule/checkpoints/`, the engine fetches it from [CorridorKey's HuggingFace](https://huggingface.co/nikopueringer/CorridorKey_v1.0) and saves it as `CorridorKey.safetensors` (preferred — safer, no pickle). Legacy `.pth` files are still loaded automatically if already present. No manual download needed.
+    *   **CorridorKey v1.0 Model (~300MB):** Downloads automatically on first run. If no checkpoint is found in `CorridorKeyModule/checkpoints/`, the engine fetches it from [CorridorKey's HuggingFace](https://huggingface.co/nikopueringer/CorridorKey_v1.0) and saves it as `CorridorKey_v1.0.safetensors` (preferred — safer, no pickle). Legacy `.pth` files are still loaded automatically if already present. No manual download needed.
     *   **GVM Weights (Optional):** [HuggingFace: geyongtao/gvm](https://huggingface.co/geyongtao/gvm)
         *   Download using the CLI: `uv run hf download geyongtao/gvm --local-dir gvm_core/weights`
     *   **VideoMaMa Weights (Optional):** [HuggingFace: SammyLim/VideoMaMa](https://huggingface.co/SammyLim/VideoMaMa)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -216,7 +216,7 @@ class TestDiscoverCheckpoint:
         assert SAFETENSORS_EXT == MLX_EXT
 
     def test_ensure_torch_checkpoint_happy_path(self, tmp_path):
-        """Mock hf_hub_download, verify copy to CHECKPOINT_DIR/CorridorKey.safetensors."""
+        """Mock hf_hub_download, verify copy to CHECKPOINT_DIR/CorridorKey_v1.0.safetensors."""
         cached = tmp_path / "hf_cache" / HF_CHECKPOINT_FILENAME_SAFETENSORS
         cached.parent.mkdir()
         cached.write_bytes(b"fake-checkpoint-data")


### PR DESCRIPTION
## What does this change?

The Python auto-download path in `CorridorKeyModule/backend.py`
and the bundled Windows/Linux install scripts point at
HuggingFace URLs that do not match the filenames actually hosted
on the model repo.

On a fresh clone with an empty `CorridorKeyModule/checkpoints/`
directory, the Python auto-download path raises:

    RuntimeError: Failed to download CorridorKey checkpoint from
    https://huggingface.co/nikopueringer/CorridorKey_v1.0.
    Check your network connection and try again.
    Original error: 404 Client Error. Entry Not Found for url:
    https://huggingface.co/nikopueringer/CorridorKey_v1.0/resolve/main/CorridorKey.pth.

Network is fine. The URL is wrong. The error message blames the
network, which sends users looking in the wrong place first.

Running the bundled `Install_CorridorKey_Windows.bat` or
`Install_CorridorKey_Linux_Mac.sh` instead produces:

    Downloading CorridorKey.safetensors...
    curl: (22) The requested URL returned error: 404
    safetensors not available yet -- falling back to CorridorKey.pth...

The safetensors file IS available on HF; the curl URL is just
misspelled. Current installer users get silently downgraded to
the legacy `.pth` format.

Ground truth from HuggingFace's model API
(`https://huggingface.co/api/models/nikopueringer/CorridorKey_v1.0`):
the repo hosts only `CorridorKey_v1.0.safetensors` and
`CorridorKey_v1.0.pth`. The unversioned filenames
`CorridorKey.safetensors` and `CorridorKey.pth` do not exist.

Five files fixed, all one-line string changes, six insertions
and six deletions:

- `CorridorKeyModule/backend.py:33-34`:
  `HF_CHECKPOINT_FILENAME_SAFETENSORS` and `HF_CHECKPOINT_FILENAME`
  get the `_v1.0` suffix. The `.pth` constant is also corrected
  by the open PR #221; the two changes are content-identical, so
  the PRs merge cleanly either way around.
- `Install_CorridorKey_Windows.bat:64`: curl URL for the
  `.safetensors` download.
- `Install_CorridorKey_Linux_Mac.sh:79`: curl URL for the
  `.safetensors` download.
- `README.md:78`: doc claim that the auto-download saves the file
  as `CorridorKey.safetensors`, now correctly
  `CorridorKey_v1.0.safetensors`.
- `tests/test_backend.py:219`: stale docstring.

A few adjacent items were considered and deliberately left alone:

- The `.pth` URLs in the installer scripts are already correct
  (`CorridorKey_v1.0.pth`).
- The installer scripts' local save paths (`SAFETENSORS_PATH`,
  `PTH_PATH`) keep their unversioned filenames on disk, so the
  installer's idempotent `if exist` skip check still hits for
  users who ran the prior installer. `_discover_checkpoint` globs
  `*.safetensors` and `*.pth`, so the local stem does not affect
  runtime behavior.
- Prose references to the filenames in `CONTRIBUTING.md`,
  `docs/LLM_HANDOVER.md`, and the `convert_pth_to_safetensors.py`
  usage docstring describe the file formats generically, not
  specific HF paths.

## How was it tested?

- `uv run ruff format --check`: clean
- `uv run ruff check`: clean
- `uv run pytest -q --tb=short -m "not gpu"`: 363 passed, 1
  skipped (MLX), 4 deselected (GPU). Same count as upstream.
- HuggingFace API filename listing cross-checked against the
  constants via
  `https://huggingface.co/api/models/nikopueringer/CorridorKey_v1.0`.
- `uv run corridorkey --help`: exits 0.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
