### PR TITLE
fix(clip_manager): retire argparse CLI in favor of corridorkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,14 @@ By default, CorridorKey auto-detects the best available compute device: **CUDA >
 
 **Override via CLI flag:**
 ```bash
-uv run python clip_manager.py --action wizard --win_path "V:\..." --device mps
-uv run python clip_manager.py --action run_inference --device cpu
+uv run corridorkey --device mps wizard "V:\..."
+uv run corridorkey --device cpu run-inference
 ```
 
 **Override via environment variable:**
 ```bash
 export CORRIDORKEY_DEVICE=cpu
-uv run python clip_manager.py --action wizard --win_path "V:\..."
+uv run corridorkey wizard "V:\..."
 ```
 
 Priority: `--device` flag > `CORRIDORKEY_DEVICE` env var > auto-detect.
@@ -209,13 +209,13 @@ Priority: `--device` flag > `CORRIDORKEY_DEVICE` env var > auto-detect.
 
 **Confirm MPS is active:** Run with verbose logging to see which device was selected:
 ```bash
-uv run python clip_manager.py --action list 2>&1 | grep -i "device\|backend\|mps"
+uv run corridorkey list-clips 2>&1 | grep -i "device\|backend\|mps"
 ```
 
 **MPS operator errors** (`NotImplementedError: ... not implemented for 'MPS'`): Some PyTorch operations are not yet supported on MPS. Enable CPU fallback for those ops:
 ```bash
 export PYTORCH_ENABLE_MPS_FALLBACK=1
-uv run python corridorkey_cli.py wizard --win_path "/path/to/clips"
+uv run corridorkey wizard "/path/to/clips"
 ```
 
 **Silent CPU fallback**: If MPS silently falls back to CPU without this variable, the run will be much slower. Setting `PYTORCH_ENABLE_MPS_FALLBACK=1` in your shell profile (`~/.zshrc`) ensures it is always active.
@@ -304,10 +304,10 @@ CorridorKey supports two inference backends:
 Resolution: `--backend` flag > `CORRIDORKEY_BACKEND` env var > auto-detect.
 Auto mode prefers MLX on Apple Silicon when available.
 
-**Override via CLI flag (corridorkey_cli.py):**
+**Override via `--backend` flag (on `run-inference`):**
 ```bash
-uv run python corridorkey_cli.py wizard --win_path "/path/to/clips" --backend mlx
-uv run python corridorkey_cli.py run_inference --backend torch
+uv run corridorkey run-inference --backend mlx
+uv run corridorkey run-inference --backend torch
 ```
 
 ### MLX Setup (Apple Silicon)
@@ -352,7 +352,7 @@ uv run python corridorkey_cli.py run_inference --backend torch
    ```
 3. Run with auto-detection or explicit backend:
    ```bash
-   CORRIDORKEY_BACKEND=mlx uv run python clip_manager.py --action run_inference
+   CORRIDORKEY_BACKEND=mlx uv run corridorkey run-inference
    ```
 
 MLX uses img_size=2048 by default (same as Torch).

--- a/clip_manager.py
+++ b/clip_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import glob
 import logging
 import os
@@ -1004,43 +1003,17 @@ def scan_clips() -> list[ClipEntry]:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="CorridorKey Clip Manager")
-    parser.add_argument("--action", choices=["generate_alphas", "run_inference", "list", "wizard"], required=True)
-    parser.add_argument("--win_path", help=r"Windows Path (example: V:\...) for Wizard Mode", default=None)
-    parser.add_argument(
-        "--device",
-        choices=["auto", "cuda", "mps", "cpu"],
-        default="auto",
-        help="Compute device (default: auto-detect CUDA > MPS > CPU)",
+    print(
+        "clip_manager.py is no longer a command-line entry point.\n"
+        "The CLI moved to `corridorkey` in PR #67.\n"
+        "\n"
+        "Old -> new:\n"
+        "  python clip_manager.py --action list            -> corridorkey list-clips\n"
+        "  python clip_manager.py --action generate_alphas -> corridorkey generate-alphas\n"
+        "  python clip_manager.py --action run_inference   -> corridorkey run-inference\n"
+        "  python clip_manager.py --action wizard PATH     -> corridorkey wizard PATH\n"
+        "\n"
+        "Run `corridorkey --help` for the full command list.",
+        file=sys.stderr,
     )
-    parser.add_argument(
-        "--backend",
-        choices=["auto", "torch", "mlx"],
-        default="auto",
-        help="Inference backend (default: auto-detect MLX on Apple Silicon, else Torch)",
-    )
-    parser.add_argument(
-        "--max-frames",
-        type=int,
-        default=None,
-        help="Limit number of frames to process per clip (e.g. 1 for first frame only)",
-    )
-
-    args = parser.parse_args()
-
-    device = resolve_device(args.device)
-    logger.info(f"Using device: {device}")
-
-    if args.action == "list":
-        scan_clips()
-    elif args.action == "generate_alphas":
-        clips = scan_clips()
-        generate_alphas(clips, device=device)
-    elif args.action == "run_inference":
-        clips = scan_clips()
-        run_inference(clips, device=device, backend=args.backend, max_frames=args.max_frames)
-    elif args.action == "wizard":
-        if not args.win_path:
-            print("Error: --win_path required for wizard.")
-        else:
-            raise NotImplementedError("interactive_wizard is not yet implemented")
+    sys.exit(2)


### PR DESCRIPTION
## What does this change?

`clip_manager.py` still shipped an argparse `__main__` block that
predates the Typer migration in PR #67. The `wizard` action
immediately raised
`NotImplementedError("interactive_wizard is not yet implemented")`
at `clip_manager.py:1046`, because the wizard implementation had
already moved to `corridorkey_cli.py::interactive_wizard` in
commit `e54abc8`. The other three actions (`list`,
`generate_alphas`, `run_inference`) still worked but were
redundant with the `corridorkey` console script.

The `README.md` also actively documented the stale invocations:

    uv run python clip_manager.py --action wizard --win_path "V:\..."
    uv run python clip_manager.py --action run_inference --device cpu
    uv run python clip_manager.py --action list 2>&1 | grep ...
    CORRIDORKEY_BACKEND=mlx uv run python clip_manager.py --action run_inference

Any user following the README to run the wizard through
`clip_manager.py` hit the NotImplementedError immediately. The
README also had two `uv run python corridorkey_cli.py wizard
--win_path ...` stanzas that combined a non-console-script
invocation with flags that never existed on the Typer wizard
(`--win_path` was an argparse artifact; the Typer wizard takes
`path` as a positional argument).

This PR:

- Replaces the argparse `__main__` block in `clip_manager.py`
  (lines 1006-1046) with a small deprecation stub that prints
  a migration guide to stderr and exits non-zero. Users with
  existing scripts or cron jobs that invoke
  `python clip_manager.py --action ...` now see a clear
  explanation and a one-to-one mapping to `corridorkey`
  subcommands instead of the old NotImplementedError.
- Removes the now-unused `import argparse` from line 3.
- Rewrites six stale `README.md` stanzas to use the
  `corridorkey` console script and the correct Typer syntax.
- Updates the backend override section header from
  "Override via CLI flag (corridorkey_cli.py)" to
  "Override via `--backend` flag (on `run-inference`)", so
  the section reflects reality (the flag is a `run-inference`
  option, not a global).

`clip_manager.py` remains the pipeline/library module for
`generate_alphas`, `run_inference`, `run_videomama`,
`scan_clips`, etc. Only the script entry point is retired.
`docs/LLM_HANDOVER.md` prose still refers to `clip_manager.py`
as "the user-facing Command Line Wizard"; that drift belongs
to the broader documentation-consolidation work and is
deliberately out of scope for this PR.

## How was it tested?

- `uv run ruff format --check`: clean
- `uv run ruff check`: clean
- `uv run pytest -q --tb=short -m "not gpu"`: 363 passed, 1
  skipped (MLX), 4 deselected (GPU), 2 warnings. Same count
  as upstream. Both warnings are pre-existing on `main` and
  not introduced here.
- `uv run python clip_manager.py`: prints the migration guide
  to stderr, exits 2.
- `uv run corridorkey --help`: exits 0.
- Typer command and option syntax for each rewritten README
  command cross-checked against `corridorkey_cli.py` source.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
