### PR TITLE
feat(installers): pre-download CorridorKeyBlue checkpoint alongside the green one

### DIFF
--- a/Install_CorridorKey_Linux_Mac.sh
+++ b/Install_CorridorKey_Linux_Mac.sh
@@ -84,6 +84,24 @@ else
     fi
 fi
 
+# CorridorKeyBlue (dedicated blue-screen weights). Optional: the green
+# checkpoint above is the primary install. If the blue download fails — repo
+# missing, network blip, etc. — we just skip it. The Python runtime
+# (_ensure_torch_checkpoint) will retry the download on first --screen-color
+# blue use, so a failure here only costs the user a one-time 300 MB pull at
+# render time instead of bricking the install.
+BLUE_SAFETENSORS_PATH="$CKPT_DIR/CorridorKeyBlue_1.0.safetensors"
+HF_BLUE_BASE="https://huggingface.co/nikopueringer/CorridorKeyBlue_1.0/resolve/main"
+if [ -f "$BLUE_SAFETENSORS_PATH" ]; then
+    echo "CorridorKeyBlue checkpoint already exists!"
+else
+    echo "Downloading CorridorKeyBlue_1.0.safetensors (blue-screen model)..."
+    if ! curl -L --fail -o "$BLUE_SAFETENSORS_PATH" "$HF_BLUE_BASE/CorridorKeyBlue_1.0.safetensors"; then
+        echo "[INFO] Blue checkpoint not downloaded — it will fetch automatically the first time you run with --screen-color blue."
+        rm -f "$BLUE_SAFETENSORS_PATH"
+    fi
+fi
+
 echo ""
 echo "==================================================="
 echo "  Setup Complete! You are ready to key!"

--- a/Install_CorridorKey_Windows.bat
+++ b/Install_CorridorKey_Windows.bat
@@ -70,6 +70,23 @@ if exist "%SAFETENSORS_PATH%" (
     )
 )
 
+REM CorridorKeyBlue (dedicated blue-screen weights). Optional download:
+REM if it fails (repo missing, network blip, etc.) the Python runtime will
+REM retry on first --screen-color blue use, so failure here is non-fatal --
+REM users keying green plates aren't blocked by an unrelated download.
+set "BLUE_SAFETENSORS_PATH=%CKPT_DIR%\CorridorKeyBlue_1.0.safetensors"
+set "HF_BLUE_BASE=https://huggingface.co/nikopueringer/CorridorKeyBlue_1.0/resolve/main"
+if exist "%BLUE_SAFETENSORS_PATH%" (
+    echo CorridorKeyBlue checkpoint already exists!
+) else (
+    echo Downloading CorridorKeyBlue_1.0.safetensors ^(blue-screen model^)...
+    curl.exe -L --fail -o "%BLUE_SAFETENSORS_PATH%" "%HF_BLUE_BASE%/CorridorKeyBlue_1.0.safetensors"
+    if errorlevel 1 (
+        echo [INFO] Blue checkpoint not downloaded -- it will fetch automatically the first time you run with --screen-color blue.
+        if exist "%BLUE_SAFETENSORS_PATH%" del "%BLUE_SAFETENSORS_PATH%"
+    )
+)
+
 echo.
 echo ===================================================
 echo   Setup Complete! You are ready to key!


### PR DESCRIPTION
## Why

Closes #243.

The bundled installer scripts (`Install_CorridorKey_Linux_Mac.sh`, `Install_CorridorKey_Windows.bat`) currently pre-download only the green checkpoint. Anyone shooting blue gets a surprise ~300 MB HF pull on the first `--screen-color blue` run (or whenever auto-detection lands on blue) — handled lazily by `_ensure_torch_checkpoint` in Python. That's fine technically, but it's a foot-gun for headless / Nuke / render-farm contexts where "the keyer mysteriously stalls for a few minutes mid-job" is hard to diagnose.

This PR makes the installer fetch both checkpoints up front, the same way it already fetches the green one.

## What changes

Both installer scripts now download `CorridorKeyBlue_1.0.safetensors` from `huggingface.co/nikopueringer/CorridorKeyBlue_1.0` right after the green block, into the same `CorridorKeyModule/checkpoints/` directory. The block mirrors the existing green logic byte-for-byte.

Two design choices worth flagging:

1. **Blue download is best-effort.** If `curl --fail` returns non-zero (HF repo deleted, transient 5xx, network blocked), the script logs an info message and continues. The install still completes. The Python runtime's `_ensure_torch_checkpoint("blue")` will retry on first use. Failure here is at most a deferred download, never a broken install.

2. **Existence check is "file present?" not "checksum matches?"** Same as the existing green block. Keeps the scripts grep-able and easy to audit. If we ever need integrity validation, the place to add it is the Python runtime, not the shell.

## How I verified

```
bash -n Install_CorridorKey_Linux_Mac.sh   # syntax OK
```

The .bat script mirrors the existing green block's structure exactly: same `if exist` / `else` shape, same `curl.exe -L --fail` flags, same `errorlevel 1` check, same `^(...^)` escapes. No new constructs.

## Why this is its own PR

Plan for #241 (the Python feature itself) deliberately scoped installers out — the runtime auto-download path is already exercised and working. This is a UX improvement on top: it doesn't change any code path, just front-loads a download that would otherwise happen lazily. Easier to review and revert independently if a build farm wants to pin the green-only behaviour for some reason.

## Test plan

- [x] Bash syntax check (`bash -n`) passes.
- [x] Both scripts mirror the structure of the green block (no new shell constructs).
- [ ] Smoke install on a clean machine (Niko or a CI runner can validate that a fresh `Install_CorridorKey_*.sh/bat` ends up with both `.safetensors` files in `checkpoints/`).