### PR TITLE
fix: update timm to version with hiera patch to remove git dependence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # Core inference
     "torch==2.8.0",
     "torchvision==0.23.0",
-    "timm==1.0.24",
+    "timm==1.0.26",
     "safetensors",
     "numpy",
     "opencv-python",
@@ -138,8 +138,6 @@ explicit = true
 extra = "rocm"
 
 [tool.uv.sources]
-# Use Hiera fix in order to utilize the FlashAttention Kernel
-timm = { git = "https://github.com/Raiden129/pytorch-image-models-fix", branch = "fix/hiera-flash-attention-global-4d" }
 torch = [
     { index = "pytorch", extra = "cuda" },
     { index = "pytorch-rocm", extra = "rocm" },

--- a/tests/test_pbt_dep_preservation.py
+++ b/tests/test_pbt_dep_preservation.py
@@ -28,7 +28,7 @@ PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
 # Known original non-torch, non-torchvision base dependencies from the design doc.
 # These are the dependencies that MUST be preserved after the restructuring.
 KNOWN_ORIGINAL_NON_TORCH_DEPS: list[str] = [
-    "timm==1.0.24",
+    "timm==1.0.26",
     "numpy",
     "opencv-python",
     "tqdm",

--- a/tests/test_pyproject_structure.py
+++ b/tests/test_pyproject_structure.py
@@ -128,27 +128,6 @@ class TestConflicts:
 
 
 # ---------------------------------------------------------------------------
-# Requirement 6.2: timm git source override preserved
-# ---------------------------------------------------------------------------
-
-
-class TestTimmSourcePreserved:
-    """Validates: Requirements 6.2"""
-
-    def test_timm_source_is_git(self, pyproject: dict) -> None:
-        timm_src = pyproject["tool"]["uv"]["sources"]["timm"]
-        assert "git" in timm_src, "timm source should be a git override"
-
-    def test_timm_git_url(self, pyproject: dict) -> None:
-        timm_src = pyproject["tool"]["uv"]["sources"]["timm"]
-        assert timm_src["git"] == "https://github.com/Raiden129/pytorch-image-models-fix"
-
-    def test_timm_git_branch(self, pyproject: dict) -> None:
-        timm_src = pyproject["tool"]["uv"]["sources"]["timm"]
-        assert timm_src["branch"] == "fix/hiera-flash-attention-global-4d"
-
-
-# ---------------------------------------------------------------------------
 # Requirement 6.3: triton-windows platform-conditional dependency preserved
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13" },
     { name = "safetensors" },
     { name = "setuptools" },
-    { name = "timm", git = "https://github.com/Raiden129/pytorch-image-models-fix?branch=fix%2Fhiera-flash-attention-global-4d" },
+    { name = "timm", specifier = "==1.0.26" },
     { name = "torch", specifier = "==2.8.0" },
     { name = "torch", marker = "extra == 'cuda'", specifier = "==2.8.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "corridorkey", extra = "cuda" } },
     { name = "torch", marker = "extra == 'rocm'", specifier = "==2.8.0", index = "https://download.pytorch.org/whl/rocm6.3", conflict = { package = "corridorkey", extra = "rocm" } },
@@ -2061,8 +2061,8 @@ wheels = [
 
 [[package]]
 name = "timm"
-version = "1.0.25"
-source = { git = "https://github.com/Raiden129/pytorch-image-models-fix?branch=fix%2Fhiera-flash-attention-global-4d#fc1dca92c5a44d5436605dacb19594117ce2eb0c" }
+version = "1.0.26"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
@@ -2073,6 +2073,10 @@ dependencies = [
     { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-corridorkey-mlx' or (extra == 'extra-11-corridorkey-cuda' and extra == 'extra-11-corridorkey-rocm') or (extra != 'extra-11-corridorkey-cuda' and extra != 'extra-11-corridorkey-rocm')" },
     { name = "torchvision", version = "0.23.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-11-corridorkey-cuda' or (extra == 'extra-11-corridorkey-mlx' and extra == 'extra-11-corridorkey-rocm')" },
     { name = "torchvision", version = "0.23.0+rocm6.3", source = { registry = "https://download.pytorch.org/whl/rocm6.3" }, marker = "(extra == 'extra-11-corridorkey-cuda' and extra == 'extra-11-corridorkey-mlx') or (extra != 'extra-11-corridorkey-mlx' and extra == 'extra-11-corridorkey-rocm') or (extra != 'extra-11-corridorkey-cuda' and extra == 'extra-11-corridorkey-rocm')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/1e/e924b3b2326a856aaf68586f9c52a5fc81ef45715eca408393b68c597e0e/timm-1.0.26.tar.gz", hash = "sha256:f66f082f2f381cf68431c22714c8b70f723837fa2a185b155961eab90f2d5b10", size = 2419859, upload-time = "2026-03-23T18:12:10.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl", hash = "sha256:985c330de5ccc3a2aa0224eb7272e6a336084702390bb7e3801f3c91603d3683", size = 2568766, upload-time = "2026-03-23T18:12:08.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this change?

Remove the dependence on git for installations, by using a timm version with @Raiden129's patch.

This should close #171 and #238. This would also stop all the requests for help with this issue on Discord.

## How was it tested?

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
