### PR TITLE
fix: broaden exception clause

### DIFF
--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -207,7 +207,7 @@ class CorridorKeyEngine:
             self.model = compiled_model
             logger.info("Model compiled successfully (mode=%s)", compile_mode)
 
-        except (RuntimeError, OSError) as e:
+        except Exception as e:
             logger.info(f"Compilation error: {e}")
             logger.warning("Model compilation failed. Falling back to eager mode.")
             if torch.cuda.is_available():


### PR DESCRIPTION
## What does this change?

Broadening the exception clause allows the model to fall back to eager mode in case of unexpected compile errors.
(There is currently a compilation issue on Windows, which blocks Windows users from using CorridorKey)

## How was it tested?
Tests pass and if this introduces unexpected behavior, something severely wrong is happening

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
