### PR TITLE
fix(backend): resolve MLX and Torch .safetensors checkpoint collision

### DIFF
--- a/CorridorKeyModule/backend.py
+++ b/CorridorKeyModule/backend.py
@@ -44,6 +44,16 @@ HF_CHECKPOINT_FILENAME_BLUE = "CorridorKeyBlue_1.0.pth"  # DEPRECATED: remove af
 # Re-exported alias for callers/tests that import VALID_SCREEN_COLORS from this module.
 VALID_SCREEN_COLORS = SCREEN_COLOR_CHOICES
 BLUE_FILENAME_TOKEN = "blue"  # case-insensitive substring marking a blue checkpoint
+# Both backends use the .safetensors extension, so the MLX-format weights are
+# distinguished by this token in the filename (see MLX_MODEL_FILENAME). Torch
+# discovery must exclude MLX files and vice-versa, otherwise the two coexisting
+# in CHECKPOINT_DIR (as the README's MLX setup instructs) collide as "Multiple
+# checkpoints".
+MLX_FILENAME_TOKEN = "mlx"
+
+
+def _is_mlx_file(path: str) -> bool:
+    return MLX_FILENAME_TOKEN in os.path.basename(path).lower()
 
 
 def resolve_backend(requested: str | None = None) -> str:
@@ -271,7 +281,9 @@ def _discover_checkpoint(ext: str, screen_color: str = "green") -> Path:
         raise ValueError(f"Unknown screen_color '{screen_color}'. Valid: {', '.join(VALID_SCREEN_COLORS)}")
 
     if ext == TORCH_EXT:
-        safetensors_matches = _filter_by_color(_find_single(SAFETENSORS_EXT), screen_color)
+        # Exclude MLX-format .safetensors so it doesn't collide with the Torch weights.
+        torch_safetensors = [p for p in _find_single(SAFETENSORS_EXT) if not _is_mlx_file(p)]
+        safetensors_matches = _filter_by_color(torch_safetensors, screen_color)
         pth_matches = _filter_by_color(_find_single(TORCH_EXT), screen_color)
 
         if safetensors_matches and pth_matches:
@@ -302,14 +314,16 @@ def _discover_checkpoint(ext: str, screen_color: str = "green") -> Path:
             "Use --backend torch with --screen-color blue, or wait for the MLX blue release."
         )
 
-    matches = _filter_by_color(_find_single(ext), screen_color)
+    candidates = _filter_by_color(_find_single(ext), screen_color)
+    # When an MLX-named file is present, use it — this disambiguates the MLX
+    # weights from a Torch .safetensors coexisting in the same dir (the README's
+    # MLX setup puts both there). Otherwise any lone .safetensors is the MLX file.
+    mlx_named = [p for p in candidates if _is_mlx_file(p)]
+    matches = mlx_named or candidates
 
     if len(matches) == 0:
-        other_ext = TORCH_EXT
-        other_files = glob.glob(os.path.join(CHECKPOINT_DIR, f"*{other_ext}"))
-        hint = ""
-        if other_files:
-            hint = f" (Found {other_ext} files — did you mean --backend=torch?)"
+        other_files = glob.glob(os.path.join(CHECKPOINT_DIR, f"*{TORCH_EXT}"))
+        hint = " (Found .pth files — did you mean --backend=torch?)" if other_files else ""
         raise FileNotFoundError(f"No {ext} {screen_color} checkpoint found in {CHECKPOINT_DIR}.{hint}")
 
     if len(matches) > 1:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -163,6 +163,20 @@ class TestDiscoverCheckpoint:
                 assert result == sft_ckpt
                 mock_dl.assert_not_called()
 
+    def test_torch_and_mlx_safetensors_coexist(self, tmp_path):
+        """The MLX setup puts corridorkey_mlx.safetensors next to the Torch
+        .safetensors. Both backends must resolve to their own weights instead of
+        colliding as "Multiple ... checkpoints"."""
+        torch_ckpt = tmp_path / "CorridorKey_v1.0.safetensors"
+        mlx_ckpt = tmp_path / "corridorkey_mlx.safetensors"
+        torch_ckpt.touch()
+        mlx_ckpt.touch()
+        with mock.patch("CorridorKeyModule.backend.CHECKPOINT_DIR", str(tmp_path)):
+            with mock.patch("huggingface_hub.hf_hub_download") as mock_dl:
+                assert _discover_checkpoint(TORCH_EXT) == torch_ckpt
+                assert _discover_checkpoint(MLX_EXT) == mlx_ckpt
+                mock_dl.assert_not_called()
+
     def test_ensure_torch_checkpoint_falls_back_to_pth_on_entry_not_found(self, tmp_path):
         """When HF does not yet host the .safetensors, _ensure_torch_checkpoint downloads the .pth."""
         from huggingface_hub.utils import EntryNotFoundError


### PR DESCRIPTION
The MLX setup in the README places the MLX weights at CorridorKeyModule/checkpoints/corridorkey_mlx.safetensors, next to the auto-downloaded Torch checkpoint (CorridorKey_v1.0.safetensors). Checkpoint discovery distinguished checkpoints by screen colour (the "blue" filename token) but not by backend, and both backends share the .safetensors extension. With two "green" .safetensors present, both the Torch and the MLX path raised "Multiple ... checkpoints. Keep exactly one." — so following the documented MLX setup broke inference on *both* backends.

Make discovery backend-aware via an "mlx" filename token (mirroring the existing BLUE_FILENAME_TOKEN convention and the MLX_MODEL_FILENAME constant):

- Torch discovery excludes MLX-named .safetensors files.
- MLX discovery prefers an MLX-named file when present, but still falls back to any lone .safetensors so the previous contract is preserved.

Adds a regression test covering the coexistence case; it fails on the prior code with the exact "Multiple ... checkpoints" error and passes with the fix.

## What does this change?

## How was it tested?

## Checklist

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` passes
- [ ] `uv run ruff format --check` passes
