### PR TITLE
fix: seek video captures to the start of a partial frame range

### DIFF
--- a/backend/service.py
+++ b/backend/service.py
@@ -592,6 +592,17 @@ class CorridorKeyService:
         job: GPUJob | None,
     ) -> None:
         """Read frames ahead of GPU processing in a background thread."""
+        # Video captures decode sequentially from frame 0, but frame_indices
+        # can start mid-clip (in/out markers). Seek first so the decoded
+        # content matches the labeled frame index — otherwise a range of
+        # 100-200 silently processes frames 0-100 under the wrong stems.
+        first_index = next(iter(frame_indices), 0)
+        if first_index > 0:
+            if input_cap is not None:
+                input_cap.set(cv2.CAP_PROP_POS_FRAMES, first_index)
+            if alpha_cap is not None:
+                alpha_cap.set(cv2.CAP_PROP_POS_FRAMES, first_index)
+
         for i in frame_indices:
             if job and job.is_cancelled:
                 break

--- a/tests/test_prefetch_video_seek.py
+++ b/tests/test_prefetch_video_seek.py
@@ -1,0 +1,88 @@
+"""Video assets must be seeked to the start of a partial frame range.
+
+VideoCapture decodes sequentially from frame 0, so when run_inference is
+given in/out markers the prefetch thread has to seek before reading —
+otherwise frame 0's content is processed under the range-start stem (and
+video assets desync from image-sequence assets, which index directly).
+"""
+
+from queue import Queue
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pytest
+
+from backend.service import CorridorKeyService
+
+FRAME_COUNT = 24
+STEP = 8  # gray value per frame index; large enough to survive lossy encoding
+TOLERANCE = 3.0
+
+
+@pytest.fixture(scope="module")
+def index_encoded_video(tmp_path_factory):
+    """A tiny video whose frame N is solid gray with value N * STEP."""
+    path = str(tmp_path_factory.mktemp("video") / "encoded.mp4")
+    writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), 24.0, (32, 32))
+    if not writer.isOpened():
+        pytest.skip("OpenCV VideoWriter unavailable in this environment")
+    for i in range(FRAME_COUNT):
+        writer.write(np.full((32, 32, 3), i * STEP, dtype=np.uint8))
+    writer.release()
+
+    probe = cv2.VideoCapture(path)
+    ok, _ = probe.read()
+    probe.release()
+    if not ok:
+        pytest.skip("OpenCV cannot read back mp4v video in this environment")
+    return path
+
+
+def _decoded_index(mean_value: float) -> float:
+    """Map a frame's mean pixel value back to the frame index it encodes."""
+    return mean_value * 255.0 / STEP
+
+
+def _run_prefetch(video_path: str, frame_indices) -> list[tuple]:
+    service = CorridorKeyService()
+    clip = SimpleNamespace(name="seek-test")
+    input_cap = cv2.VideoCapture(video_path)
+    alpha_cap = cv2.VideoCapture(video_path)
+    q: Queue = Queue()
+    try:
+        service._prefetch_frames(clip, frame_indices, [], [], input_cap, alpha_cap, False, q, None)
+    finally:
+        input_cap.release()
+        alpha_cap.release()
+
+    items = []
+    while True:
+        item = q.get_nowait()
+        if item is None:
+            break
+        items.append(item)
+    return items
+
+
+def test_partial_range_reads_matching_frames(index_encoded_video):
+    start, end = 10, 15
+    items = _run_prefetch(index_encoded_video, range(start, end + 1))
+
+    assert [item[0] for item in items] == list(range(start, end + 1))
+    for i, img, mask, stem, _is_linear, err in items:
+        assert err is None
+        assert stem == f"{i:05d}"
+        assert img is not None and mask is not None
+        assert _decoded_index(img.mean()) == pytest.approx(i, abs=TOLERANCE), (
+            f"frame labeled {i} contains content of frame {_decoded_index(img.mean()):.1f}"
+        )
+        assert _decoded_index(mask.mean()) == pytest.approx(i, abs=TOLERANCE)
+
+
+def test_full_range_is_unaffected(index_encoded_video):
+    items = _run_prefetch(index_encoded_video, range(0, 5))
+
+    for i, img, _mask, _stem, _is_linear, err in items:
+        assert err is None
+        assert _decoded_index(img.mean()) == pytest.approx(i, abs=TOLERANCE)


### PR DESCRIPTION
## What does this change?

`run_inference`'s prefetch thread iterates `frame_indices`, which can start mid-clip when in/out markers set a `frame_range` — but `_read_input_frame` / `_read_alpha_frame` read video assets with sequential `cap.read()` calls starting at frame 0. Two consequences:

- A range of 100–200 silently processed the **content of frames 0–100** while writing them under stems `00100`–`00200`.
- Mixed-asset clips desynced: an image-sequence asset indexes files by the true frame index while the paired video asset started at 0, so inputs were keyed against the wrong mattes.

Fix: seek both captures (`CAP_PROP_POS_FRAMES`) to the first requested index before the prefetch loop starts — the same random-access mechanism `frame_io.read_video_frame_at` already uses. Full-clip runs (range starting at 0) are untouched.

## How was it tested?

- New regression test (`tests/test_prefetch_video_seek.py`): a synthetic video where each frame's pixel value encodes its own index, prefetched over a partial range — asserts decoded content matches the labeled stem for both input and alpha captures. **Fails on main, passes with the fix.**
- Full suite: `uv run pytest` — no new failures (one pre-existing, unrelated flake in `test_pbt_auto_download.py` reproduces identically on a clean checkout of main; happy to file separately).
- Verified on Apple Silicon, Python 3.13.

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)