### PR TITLE
anchor gamma-consistency refs to functions, not line numbers

### DIFF
--- a/tests/test_gamma_consistency.py
+++ b/tests/test_gamma_consistency.py
@@ -9,9 +9,10 @@ The codebase uses two different methods to convert between linear and sRGB:
    This follows the IEC 61966-2-1 spec: exponent 2.4 with a linear segment
    below the breakpoint.
 
-2. **Gamma 2.2 approximation** — used by ``clip_manager.py:383`` (VideoMaMa
-   frame loading) and ``gvm_core/gvm/utils/inference_utils.py:124`` (GVM
-   frame loading).  This uses a simple ``x ** (1/2.2)`` power curve.
+2. **Gamma 2.2 approximation** — used by ``clip_manager.run_videomama()``
+   (VideoMaMa frame loading) and ``ImageSequenceReader.__getitem__()`` in
+   ``gvm_core/gvm/utils/inference_utils.py`` (GVM frame loading).  This uses
+   a simple ``x ** (1/2.2)`` power curve.
 
 The two methods produce visibly different results, especially in darks.
 At linear 0.01, the difference is ~4.7% — enough to see in a waveform monitor.


### PR DESCRIPTION
## What does this change?

Fixes a stale code reference in the `test_gamma_consistency.py` docstring. It cited `clip_manager.py:383` for the VideoMaMa gamma-2.2 conversion, but that path has since moved, line 383 is now unrelated code, and the actual `img ** (1.0 / 2.2)` lives in `run_videomama()`.

Rather than swap in the new line number (which will rot the next time that function is edited), this anchors **both** gamma-2.2 references to their functions — `clip_manager.run_videomama()` and `ImageSequenceReader.__getitem__()`. This also brings point 2 in line with point 1 of the same docstring, which already references functions rather than line numbers.

No behavioral change, documentation only.

## How was it tested?

- `uv run pytest tests/test_gamma_consistency.py` — 8 passed
- `uv run ruff check` / `uv run ruff format --check` — clean

## Checklist

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
